### PR TITLE
feat 검색 기능

### DIFF
--- a/client/src/Components/Global/Header/Clock.js
+++ b/client/src/Components/Global/Header/Clock.js
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 import styled from "styled-components";
 
 const Div = styled.div`
-  width: auto;
-  height: auto;
+  width: 100px;
+  height: 60px;
   padding: 15px;
   font-size: 1.2em;
   font-family: "Oswald";

--- a/client/src/Components/Global/Header/Search/Autocomplete.js
+++ b/client/src/Components/Global/Header/Search/Autocomplete.js
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+import data from "../data";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+const List = styled.li`
+  display: block;
+  width: 500px;
+  height: 30px;
+  border: solid 1.5px #495464;
+  border-top: none;
+  border-radius: 3px;
+  z-index: 100;
+  background-color: white;
+  font-size: 0.8em;
+  padding: 5px 9px;
+`;
+const Autocomplete = ({ keyword }) => {
+  const navigate = useNavigate();
+
+  const [similar, setSimilar] = useState([]);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSimilar(data.filter((el) => el.itmsNm.includes(keyword)));
+    }, 1000);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [keyword]);
+
+  return (
+    <ul>
+      {similar.map((el) => (
+        <List
+          key={el.srtnCd}
+          onClick={() => {
+            navigate(`/stock/${el.srtnCd} `, {
+              state: { name: `${el.itmsNm}` },
+            });
+            setSimilar([]);
+          }}
+        >
+          {el.itmsNm} Go
+        </List>
+      ))}
+    </ul>
+  );
+};
+
+export default Autocomplete;

--- a/client/src/Components/Global/Header/Search/index.js
+++ b/client/src/Components/Global/Header/Search/index.js
@@ -1,0 +1,36 @@
+// 헤더 검색창 기능 구현
+// 코드 srtnCd, 이름 itmsNm
+
+import Autocomplete from "./Autocomplete";
+import styled from "styled-components";
+import { useState } from "react";
+
+const Div = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Input = styled.input`
+  display: flex;
+  width: 500px;
+  height: 30px;
+  border: solid 1.5px #495464;
+  border-radius: 3px;
+  margin: 15px 10px 0 0;
+  padding-left: 9px;
+`;
+
+const Search = () => {
+  const [keyword, setKeyword] = useState("");
+  return (
+    <Div>
+      <Input
+        placeholder="어떤 종목이 궁금하세요?"
+        type="text"
+        onChange={(e) => setKeyword(e.target.value)}
+      ></Input>
+      {keyword.length ? <Autocomplete keyword={keyword} /> : <></>}
+    </Div>
+  );
+};
+export default Search;

--- a/client/src/Components/Global/Header/data.json
+++ b/client/src/Components/Global/Header/data.json
@@ -1,0 +1,16127 @@
+[
+  {
+    "srtnCd": "098120",
+    "fullNm": "(주)마이크로컨텍솔루션",
+    "itmsNm": "마이크로컨텍솔",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009520",
+    "fullNm": "(주)포스코엠텍",
+    "itmsNm": "포스코엠텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "095570",
+    "fullNm": "AJ네트웍스보통주",
+    "itmsNm": "AJ네트웍스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006840",
+    "fullNm": "AK홀딩스보통주",
+    "itmsNm": "AK홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "282330",
+    "fullNm": "BGF리테일보통주",
+    "itmsNm": "BGF리테일",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "027410",
+    "fullNm": "BGF보통주",
+    "itmsNm": "BGF",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "138930",
+    "fullNm": "BNK금융지주보통주",
+    "itmsNm": "BNK금융지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001465",
+    "fullNm": "BYC1우선주",
+    "itmsNm": "BYC우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001460",
+    "fullNm": "BYC보통주",
+    "itmsNm": "BYC",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001045",
+    "fullNm": "CJ1우선주",
+    "itmsNm": "CJ우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "00104K",
+    "fullNm": "CJ4우선주(전환)",
+    "itmsNm": "CJ4우(전환)",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001040",
+    "fullNm": "CJ보통주",
+    "itmsNm": "CJ",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011155",
+    "fullNm": "CJ씨푸드1우선주",
+    "itmsNm": "CJ씨푸드1우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011150",
+    "fullNm": "CJ씨푸드보통주",
+    "itmsNm": "CJ씨푸드",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "058820",
+    "fullNm": "CMG제약",
+    "itmsNm": "CMG제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000590",
+    "fullNm": "CS홀딩스보통주",
+    "itmsNm": "CS홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012030",
+    "fullNm": "DB Inc.보통주",
+    "itmsNm": "DB",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "016610",
+    "fullNm": "DB금융투자보통주",
+    "itmsNm": "DB금융투자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005830",
+    "fullNm": "DB손해보험보통주",
+    "itmsNm": "DB손해보험",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000995",
+    "fullNm": "DB하이텍1우선주",
+    "itmsNm": "DB하이텍1우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000990",
+    "fullNm": "DB하이텍보통주",
+    "itmsNm": "DB하이텍",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "139130",
+    "fullNm": "DGB금융지주보통주",
+    "itmsNm": "DGB금융지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001530",
+    "fullNm": "DI동일보통주",
+    "itmsNm": "DI동일",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000215",
+    "fullNm": "DL1우선주",
+    "itmsNm": "DL우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001880",
+    "fullNm": "DL건설보통주",
+    "itmsNm": "DL건설",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000210",
+    "fullNm": "DL보통주",
+    "itmsNm": "DL",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "37550K",
+    "fullNm": "DL이앤씨1우선주",
+    "itmsNm": "DL이앤씨우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "37550L",
+    "fullNm": "DL이앤씨2우선주(전환)",
+    "itmsNm": "DL이앤씨2우(전환)",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "375500",
+    "fullNm": "DL이앤씨보통주",
+    "itmsNm": "DL이앤씨",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "155660",
+    "fullNm": "DSR보통주",
+    "itmsNm": "DSR",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "069730",
+    "fullNm": "DSR제강보통주",
+    "itmsNm": "DSR제강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "017940",
+    "fullNm": "E1보통주",
+    "itmsNm": "E1",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "365550",
+    "fullNm": "ESR켄달스퀘어리츠보통주",
+    "itmsNm": "ESR켄달스퀘어리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "050120",
+    "fullNm": "ES큐브",
+    "itmsNm": "ES큐브",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "383220",
+    "fullNm": "F&F보통주",
+    "itmsNm": "F&F",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007700",
+    "fullNm": "F&F홀딩스",
+    "itmsNm": "F&F홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "078935",
+    "fullNm": "GS1우선주",
+    "itmsNm": "GS우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006360",
+    "fullNm": "GS건설보통주",
+    "itmsNm": "GS건설",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "078930",
+    "fullNm": "GS보통주",
+    "itmsNm": "GS",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012630",
+    "fullNm": "HDC보통주",
+    "itmsNm": "HDC",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "294870",
+    "fullNm": "HDC현대산업개발보통주",
+    "itmsNm": "HDC현대산업개발",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "097230",
+    "fullNm": "HJ중공업보통주",
+    "itmsNm": "HJ중공업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "014790",
+    "fullNm": "HL D&I보통주",
+    "itmsNm": "HL D&I",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "204320",
+    "fullNm": "HL만도보통주",
+    "itmsNm": "HL만도",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "060980",
+    "fullNm": "HL홀딩스보통주",
+    "itmsNm": "HL홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003560",
+    "fullNm": "IHQ보통주",
+    "itmsNm": "IHQ",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "175330",
+    "fullNm": "JB금융지주보통주",
+    "itmsNm": "JB금융지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "234080",
+    "fullNm": "JW생명과학보통주",
+    "itmsNm": "JW생명과학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001065",
+    "fullNm": "JW중외제약1우선주",
+    "itmsNm": "JW중외제약우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001067",
+    "fullNm": "JW중외제약2우선주(신형)",
+    "itmsNm": "JW중외제약2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001060",
+    "fullNm": "JW중외제약보통주",
+    "itmsNm": "JW중외제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "096760",
+    "fullNm": "JW홀딩스 보통주",
+    "itmsNm": "JW홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "105560",
+    "fullNm": "KB금융지주 보통주",
+    "itmsNm": "KB금융",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "432320",
+    "fullNm": "KB스타리츠보통주",
+    "itmsNm": "KB스타리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "024120",
+    "fullNm": "KB오토시스",
+    "itmsNm": "KB오토시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009070",
+    "fullNm": "KCTC 보통주",
+    "itmsNm": "KCTC",
+    "mrktCtg": "KOSPI"
+  },
+  { "srtnCd": "044180", "fullNm": "KD", "itmsNm": "KD", "mrktCtg": "KOSDAQ" },
+  {
+    "srtnCd": "016380",
+    "fullNm": "KG스틸보통주",
+    "itmsNm": "KG스틸",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001390",
+    "fullNm": "KG케미칼보통주",
+    "itmsNm": "KG케미칼",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "033180",
+    "fullNm": "KH 필룩스보통주",
+    "itmsNm": "KH 필룩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001940",
+    "fullNm": "KISCO홀딩스보통주",
+    "itmsNm": "KISCO홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "025000",
+    "fullNm": "KPX케미칼보통주",
+    "itmsNm": "KPX케미칼",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "092230",
+    "fullNm": "KPX홀딩스보통주",
+    "itmsNm": "KPX홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000040",
+    "fullNm": "KR모터스보통주",
+    "itmsNm": "KR모터스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "093050",
+    "fullNm": "LF보통주",
+    "itmsNm": "LF",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003555",
+    "fullNm": "LG1우선주",
+    "itmsNm": "LG우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "034220",
+    "fullNm": "LG디스플레이보통주",
+    "itmsNm": "LG디스플레이",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003550",
+    "fullNm": "LG보통주",
+    "itmsNm": "LG",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "051905",
+    "fullNm": "LG생활건강1우선주",
+    "itmsNm": "LG생활건강우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "051900",
+    "fullNm": "LG생활건강보통주",
+    "itmsNm": "LG생활건강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "373220",
+    "fullNm": "LG에너지솔루션보통주",
+    "itmsNm": "LG에너지솔루션",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "032640",
+    "fullNm": "LG유플러스보통주",
+    "itmsNm": "LG유플러스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011070",
+    "fullNm": "LG이노텍보통주",
+    "itmsNm": "LG이노텍",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "066575",
+    "fullNm": "LG전자1우선주",
+    "itmsNm": "LG전자우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "066570",
+    "fullNm": "LG전자보통주",
+    "itmsNm": "LG전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "051915",
+    "fullNm": "LG화학1우선주",
+    "itmsNm": "LG화학우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "051910",
+    "fullNm": "LG화학보통주",
+    "itmsNm": "LG화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "079550",
+    "fullNm": "LIG넥스원보통주",
+    "itmsNm": "LIG넥스원",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "010120",
+    "fullNm": "LS ELECTRIC보통주",
+    "itmsNm": "LS ELECTRIC",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000680",
+    "fullNm": "LS네트웍스보통주",
+    "itmsNm": "LS네트웍스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006260",
+    "fullNm": "LS보통주",
+    "itmsNm": "LS",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "108320",
+    "fullNm": "LX세미콘보통주",
+    "itmsNm": "LX세미콘",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001120",
+    "fullNm": "LX인터내셔널보통주",
+    "itmsNm": "LX인터내셔널",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "086960",
+    "fullNm": "MDS테크",
+    "itmsNm": "MDS테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "023150",
+    "fullNm": "MH에탄올보통주",
+    "itmsNm": "MH에탄올",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "035420",
+    "fullNm": "NAVER보통주",
+    "itmsNm": "NAVER",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "181710",
+    "fullNm": "NHN보통주",
+    "itmsNm": "NHN",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "338100",
+    "fullNm": "NH프라임리츠보통주",
+    "itmsNm": "NH프라임리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "034310",
+    "fullNm": "NICE보통주",
+    "itmsNm": "NICE",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "008260",
+    "fullNm": "NI스틸보통주",
+    "itmsNm": "NI스틸",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004255",
+    "fullNm": "NPC1우선주",
+    "itmsNm": "NPC우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004250",
+    "fullNm": "NPC보통주",
+    "itmsNm": "NPC",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "010060",
+    "fullNm": "OCI보통주",
+    "itmsNm": "OCI",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "010955",
+    "fullNm": "S-Oil1우선주",
+    "itmsNm": "S-Oil우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "010950",
+    "fullNm": "S-Oil보통주",
+    "itmsNm": "S-Oil",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "950110",
+    "fullNm": "SBI핀테크솔루션즈",
+    "itmsNm": "SBI핀테크솔루션즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005090",
+    "fullNm": "SGC에너지보통주",
+    "itmsNm": "SGC에너지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001380",
+    "fullNm": "SG글로벌보통주",
+    "itmsNm": "SG글로벌",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001770",
+    "fullNm": "SHD보통주",
+    "itmsNm": "SHD",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002360",
+    "fullNm": "SH에너지화학보통주",
+    "itmsNm": "SH에너지화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009160",
+    "fullNm": "SIMPAC보통주",
+    "itmsNm": "SIMPAC",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "123700",
+    "fullNm": "SJM보통주",
+    "itmsNm": "SJM",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "025530",
+    "fullNm": "SJM홀딩스보통주",
+    "itmsNm": "SJM홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "03473K",
+    "fullNm": "SK1우선주",
+    "itmsNm": "SK우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011790",
+    "fullNm": "SKC보통주",
+    "itmsNm": "SKC",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "018670",
+    "fullNm": "SK가스보통주",
+    "itmsNm": "SK가스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001745",
+    "fullNm": "SK네트웍스1우선주",
+    "itmsNm": "SK네트웍스우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001740",
+    "fullNm": "SK네트웍스보통주",
+    "itmsNm": "SK네트웍스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "210980",
+    "fullNm": "SK디앤디보통주",
+    "itmsNm": "SK디앤디",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "395400",
+    "fullNm": "SK리츠보통주",
+    "itmsNm": "SK리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "034730",
+    "fullNm": "SK보통주",
+    "itmsNm": "SK",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "402340",
+    "fullNm": "SK스퀘어보통주",
+    "itmsNm": "SK스퀘어",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "260870",
+    "fullNm": "SK시그넷",
+    "itmsNm": "SK시그넷",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "361610",
+    "fullNm": "SK아이이테크놀로지보통주",
+    "itmsNm": "SK아이이테크놀로지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "096775",
+    "fullNm": "SK이노베이션 1우선주",
+    "itmsNm": "SK이노베이션우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "096770",
+    "fullNm": "SK이노베이션 보통주",
+    "itmsNm": "SK이노베이션",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001515",
+    "fullNm": "SK증권1우선주",
+    "itmsNm": "SK증권우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001510",
+    "fullNm": "SK증권보통주",
+    "itmsNm": "SK증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "28513K",
+    "fullNm": "SK케미칼1우선주",
+    "itmsNm": "SK케미칼우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "285130",
+    "fullNm": "SK케미칼보통주",
+    "itmsNm": "SK케미칼",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "017670",
+    "fullNm": "SK텔레콤보통주",
+    "itmsNm": "SK텔레콤",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "064960",
+    "fullNm": "SNT모티브보통주",
+    "itmsNm": "SNT모티브",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "100840",
+    "fullNm": "SNT에너지보통주",
+    "itmsNm": "SNT에너지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003570",
+    "fullNm": "SNT중공업보통주",
+    "itmsNm": "SNT중공업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "036530",
+    "fullNm": "SNT홀딩스보통주",
+    "itmsNm": "SNT홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005610",
+    "fullNm": "SPC삼립보통주",
+    "itmsNm": "SPC삼립",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011810",
+    "fullNm": "STX보통주",
+    "itmsNm": "STX",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "077970",
+    "fullNm": "STX엔진보통주",
+    "itmsNm": "STX엔진",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "071970",
+    "fullNm": "STX중공업보통주",
+    "itmsNm": "STX중공업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "084870",
+    "fullNm": "TBH글로벌보통주",
+    "itmsNm": "TBH글로벌",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002710",
+    "fullNm": "TCC스틸보통주",
+    "itmsNm": "TCC스틸",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "024070",
+    "fullNm": "WISCOM보통주",
+    "itmsNm": "WISCOM",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "079940",
+    "fullNm": "가비아",
+    "itmsNm": "가비아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078890",
+    "fullNm": "가온미디어",
+    "itmsNm": "가온미디어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000500",
+    "fullNm": "가온전선보통주",
+    "itmsNm": "가온전선",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "399720",
+    "fullNm": "가온칩스",
+    "itmsNm": "가온칩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036620",
+    "fullNm": "감성코퍼레이션",
+    "itmsNm": "감성코퍼레이션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000860",
+    "fullNm": "강남제비스코보통주",
+    "itmsNm": "강남제비스코",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "217730",
+    "fullNm": "강스템바이오텍",
+    "itmsNm": "강스템바이오텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "035250",
+    "fullNm": "강원랜드보통주",
+    "itmsNm": "강원랜드",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "114190",
+    "fullNm": "강원에너지",
+    "itmsNm": "강원에너지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "094480",
+    "fullNm": "갤럭시아머니트리",
+    "itmsNm": "갤럭시아머니트리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "011420",
+    "fullNm": "갤럭시아에스엠보통주",
+    "itmsNm": "갤럭시아에스엠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "039240",
+    "fullNm": "경남스틸",
+    "itmsNm": "경남스틸",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053950",
+    "fullNm": "경남제약",
+    "itmsNm": "경남제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002100",
+    "fullNm": "경농보통주",
+    "itmsNm": "경농",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009450",
+    "fullNm": "경동나비엔보통주",
+    "itmsNm": "경동나비엔",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "267290",
+    "fullNm": "경동도시가스보통주",
+    "itmsNm": "경동도시가스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012320",
+    "fullNm": "경동인베스트보통주",
+    "itmsNm": "경동인베스트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011040",
+    "fullNm": "경동제약",
+    "itmsNm": "경동제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000050",
+    "fullNm": "경방보통주",
+    "itmsNm": "경방",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "214390",
+    "fullNm": "경보제약보통주",
+    "itmsNm": "경보제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012610",
+    "fullNm": "경인양행보통주",
+    "itmsNm": "경인양행",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009140",
+    "fullNm": "경인전자보통주",
+    "itmsNm": "경인전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "024910",
+    "fullNm": "경창산업",
+    "itmsNm": "경창산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "013580",
+    "fullNm": "계룡건설산업보통주",
+    "itmsNm": "계룡건설",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012205",
+    "fullNm": "계양전기1우선주",
+    "itmsNm": "계양전기우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012200",
+    "fullNm": "계양전기보통주",
+    "itmsNm": "계양전기",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002140",
+    "fullNm": "고려산업보통주",
+    "itmsNm": "고려산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "198440",
+    "fullNm": "고려시멘트",
+    "itmsNm": "고려시멘트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049720",
+    "fullNm": "고려신용정보",
+    "itmsNm": "고려신용정보",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010130",
+    "fullNm": "고려아연보통주",
+    "itmsNm": "고려아연",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002240",
+    "fullNm": "고려제강보통주",
+    "itmsNm": "고려제강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "014570",
+    "fullNm": "고려제약",
+    "itmsNm": "고려제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "348150",
+    "fullNm": "고바이오랩",
+    "itmsNm": "고바이오랩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "098460",
+    "fullNm": "고영테크놀러지",
+    "itmsNm": "고영",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "035290",
+    "fullNm": "골드앤에스",
+    "itmsNm": "골드앤에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038530",
+    "fullNm": "골드퍼시픽",
+    "itmsNm": "골드퍼시픽",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "215000",
+    "fullNm": "골프존",
+    "itmsNm": "골프존",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "121440",
+    "fullNm": "골프존뉴딘홀딩스",
+    "itmsNm": "골프존뉴딘홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "183410",
+    "fullNm": "골프존데카",
+    "itmsNm": "골프존데카",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "366030",
+    "fullNm": "공구우먼",
+    "itmsNm": "공구우먼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "076340",
+    "fullNm": "관악산업",
+    "itmsNm": "관악산업",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "009290",
+    "fullNm": "광동제약보통주",
+    "itmsNm": "광동제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "014200",
+    "fullNm": "광림",
+    "itmsNm": "광림",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "017040",
+    "fullNm": "광명전기보통주",
+    "itmsNm": "광명전기",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "029480",
+    "fullNm": "광무",
+    "itmsNm": "광무",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "017900",
+    "fullNm": "광전자보통주",
+    "itmsNm": "광전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "037710",
+    "fullNm": "광주신세계보통주",
+    "itmsNm": "광주신세계",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "026910",
+    "fullNm": "광진실업",
+    "itmsNm": "광진실업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "355150",
+    "fullNm": "교보10호기업인수목적",
+    "itmsNm": "교보10호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "397880",
+    "fullNm": "교보11호기업인수목적",
+    "itmsNm": "교보11호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "421800",
+    "fullNm": "교보12호기업인수목적",
+    "itmsNm": "교보12호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "440790",
+    "fullNm": "교보13호기업인수목적",
+    "itmsNm": "교보13호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "030610",
+    "fullNm": "교보증권보통주",
+    "itmsNm": "교보증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "339770",
+    "fullNm": "교촌에프앤비보통주",
+    "itmsNm": "교촌에프앤비",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "053270",
+    "fullNm": "구영테크",
+    "itmsNm": "구영테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007690",
+    "fullNm": "국도화학보통주",
+    "itmsNm": "국도화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005320",
+    "fullNm": "국동보통주",
+    "itmsNm": "국동",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "066620",
+    "fullNm": "국보디자인",
+    "itmsNm": "국보디자인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001140",
+    "fullNm": "국보보통주",
+    "itmsNm": "국보",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "043650",
+    "fullNm": "국순당",
+    "itmsNm": "국순당",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006050",
+    "fullNm": "국영지앤엠",
+    "itmsNm": "국영지앤엠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060480",
+    "fullNm": "국일신동",
+    "itmsNm": "국일신동",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078130",
+    "fullNm": "국일제지",
+    "itmsNm": "국일제지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "307750",
+    "fullNm": "국전약품",
+    "itmsNm": "국전약품",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002720",
+    "fullNm": "국제약품보통주",
+    "itmsNm": "국제약품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "243870",
+    "fullNm": "굿센",
+    "itmsNm": "굿센",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "035080",
+    "fullNm": "그래디언트",
+    "itmsNm": "그래디언트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "114090",
+    "fullNm": "그랜드코리아레저보통주",
+    "itmsNm": "GKL",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "900290",
+    "fullNm": "그레이트리치과기유한공사",
+    "itmsNm": "GRT",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "204020",
+    "fullNm": "그리티",
+    "itmsNm": "그리티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "083420",
+    "fullNm": "그린케미칼보통주",
+    "itmsNm": "그린케미칼",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "186230",
+    "fullNm": "그린플러스",
+    "itmsNm": "그린플러스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "014530",
+    "fullNm": "극동유화보통주",
+    "itmsNm": "극동유화",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "083450",
+    "fullNm": "글로벌스탠다드테크놀로지",
+    "itmsNm": "GST",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "900070",
+    "fullNm": "글로벌에스엠테크리미티드",
+    "itmsNm": "글로벌에스엠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "204620",
+    "fullNm": "글로벌텍스프리",
+    "itmsNm": "글로벌텍스프리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "019660",
+    "fullNm": "글로본",
+    "itmsNm": "글로본",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "014285",
+    "fullNm": "금강공업1우선주",
+    "itmsNm": "금강공업우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "014280",
+    "fullNm": "금강공업보통주",
+    "itmsNm": "금강공업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "053260",
+    "fullNm": "금강철강",
+    "itmsNm": "금강철강",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "008870",
+    "fullNm": "금비보통주",
+    "itmsNm": "금비",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001570",
+    "fullNm": "금양보통주",
+    "itmsNm": "금양",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002995",
+    "fullNm": "금호건설1우선주",
+    "itmsNm": "금호건설우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002990",
+    "fullNm": "금호건설보통주",
+    "itmsNm": "금호건설",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011785",
+    "fullNm": "금호석유화학1우선주",
+    "itmsNm": "금호석유우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011780",
+    "fullNm": "금호석유화학보통주",
+    "itmsNm": "금호석유",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "214330",
+    "fullNm": "금호에이치티보통주",
+    "itmsNm": "금호에이치티",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001210",
+    "fullNm": "금호전기보통주",
+    "itmsNm": "금호전기",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "073240",
+    "fullNm": "금호타이어보통주",
+    "itmsNm": "금호타이어",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "036190",
+    "fullNm": "금화피에스시",
+    "itmsNm": "금화피에스시",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049080",
+    "fullNm": "기가레인",
+    "itmsNm": "기가레인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "035460",
+    "fullNm": "기산텔레콤",
+    "itmsNm": "기산텔레콤",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092440",
+    "fullNm": "기신정기 보통주",
+    "itmsNm": "기신정기",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000270",
+    "fullNm": "기아보통주",
+    "itmsNm": "기아",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "013700",
+    "fullNm": "까뮤이앤씨보통주",
+    "itmsNm": "까뮤이앤씨",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "308100",
+    "fullNm": "까스텔바작",
+    "itmsNm": "까스텔바작",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004545",
+    "fullNm": "깨끗한나라1우선주",
+    "itmsNm": "깨끗한나라우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004540",
+    "fullNm": "깨끗한나라보통주",
+    "itmsNm": "깨끗한나라",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "187790",
+    "fullNm": "나노",
+    "itmsNm": "나노",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "286750",
+    "fullNm": "나노브릭",
+    "itmsNm": "나노브릭",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "121600",
+    "fullNm": "나노신소재",
+    "itmsNm": "나노신소재",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "247660",
+    "fullNm": "나노씨엠에스",
+    "itmsNm": "나노씨엠에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039860",
+    "fullNm": "나노엔텍",
+    "itmsNm": "나노엔텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "091970",
+    "fullNm": "나노캠텍",
+    "itmsNm": "나노캠텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "244880",
+    "fullNm": "나눔테크",
+    "itmsNm": "나눔테크",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "288490",
+    "fullNm": "나라소프트",
+    "itmsNm": "나라소프트",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "051490",
+    "fullNm": "나라엠앤디",
+    "itmsNm": "나라엠앤디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "137080",
+    "fullNm": "나래나노텍",
+    "itmsNm": "나래나노텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "190510",
+    "fullNm": "나무가",
+    "itmsNm": "나무가",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "242040",
+    "fullNm": "나무기술",
+    "itmsNm": "나무기술",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "089600",
+    "fullNm": "나스미디어",
+    "itmsNm": "나스미디어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "293580",
+    "fullNm": "나우아이비캐피탈",
+    "itmsNm": "나우IB",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "257990",
+    "fullNm": "나우코스",
+    "itmsNm": "나우코스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "138610",
+    "fullNm": "나이벡",
+    "itmsNm": "나이벡",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "130580",
+    "fullNm": "나이스디앤비",
+    "itmsNm": "나이스디앤비",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036800",
+    "fullNm": "나이스정보통신",
+    "itmsNm": "나이스정보통신",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "030190",
+    "fullNm": "나이스평가정보",
+    "itmsNm": "NICE평가정보",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "267320",
+    "fullNm": "나인테크",
+    "itmsNm": "나인테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001260",
+    "fullNm": "남광토건보통주",
+    "itmsNm": "남광토건",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "008355",
+    "fullNm": "남선알미늄1우선주",
+    "itmsNm": "남선알미우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "008350",
+    "fullNm": "남선알미늄보통주",
+    "itmsNm": "남선알미늄",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004270",
+    "fullNm": "남성보통주",
+    "itmsNm": "남성",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003925",
+    "fullNm": "남양유업1우선주",
+    "itmsNm": "남양유업우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003920",
+    "fullNm": "남양유업보통주",
+    "itmsNm": "남양유업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "025860",
+    "fullNm": "남해화학보통주",
+    "itmsNm": "남해화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "111710",
+    "fullNm": "남화산업",
+    "itmsNm": "남화산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "091590",
+    "fullNm": "남화토건",
+    "itmsNm": "남화토건",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "168330",
+    "fullNm": "내츄럴엔도텍",
+    "itmsNm": "내츄럴엔도텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "094860",
+    "fullNm": "네오리진",
+    "itmsNm": "네오리진",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "253590",
+    "fullNm": "네오셈",
+    "itmsNm": "네오셈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "212560",
+    "fullNm": "네오오토",
+    "itmsNm": "네오오토",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "095660",
+    "fullNm": "네오위즈",
+    "itmsNm": "네오위즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "042420",
+    "fullNm": "네오위즈홀딩스",
+    "itmsNm": "네오위즈홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "950220",
+    "fullNm": "네오이뮨텍",
+    "itmsNm": "네오이뮨텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "311390",
+    "fullNm": "네오크레마",
+    "itmsNm": "네오크레마",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "085910",
+    "fullNm": "네오티스",
+    "itmsNm": "네오티스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092730",
+    "fullNm": "네오팜",
+    "itmsNm": "네오팜",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "290660",
+    "fullNm": "네오펙트",
+    "itmsNm": "네오펙트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "306620",
+    "fullNm": "네온테크",
+    "itmsNm": "네온테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "153460",
+    "fullNm": "네이블커뮤니케이션즈",
+    "itmsNm": "네이블",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007390",
+    "fullNm": "네이처셀",
+    "itmsNm": "네이처셀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033640",
+    "fullNm": "네패스",
+    "itmsNm": "네패스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "330860",
+    "fullNm": "네패스아크",
+    "itmsNm": "네패스아크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005725",
+    "fullNm": "넥센1우선주",
+    "itmsNm": "넥센우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005720",
+    "fullNm": "넥센보통주",
+    "itmsNm": "넥센",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002355",
+    "fullNm": "넥센타이어1우선주(신형)",
+    "itmsNm": "넥센타이어1우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002350",
+    "fullNm": "넥센타이어보통주",
+    "itmsNm": "넥센타이어",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "089140",
+    "fullNm": "넥스턴바이오사이언스",
+    "itmsNm": "넥스턴바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "137940",
+    "fullNm": "넥스트아이",
+    "itmsNm": "넥스트아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "160550",
+    "fullNm": "넥스트엔터테인먼트월드",
+    "itmsNm": "NEW",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "396270",
+    "fullNm": "넥스트칩",
+    "itmsNm": "넥스트칩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "348210",
+    "fullNm": "넥스틴",
+    "itmsNm": "넥스틴",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "225570",
+    "fullNm": "넥슨게임즈",
+    "itmsNm": "넥슨게임즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "217270",
+    "fullNm": "넵튠",
+    "itmsNm": "넵튠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "251270",
+    "fullNm": "넷마블보통주",
+    "itmsNm": "넷마블",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "317860",
+    "fullNm": "노드메이슨",
+    "itmsNm": "노드메이슨",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "104620",
+    "fullNm": "노랑풍선",
+    "itmsNm": "노랑풍선",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "090355",
+    "fullNm": "노루페인트 1우선주",
+    "itmsNm": "노루페인트우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "090350",
+    "fullNm": "노루페인트 보통주",
+    "itmsNm": "노루페인트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000325",
+    "fullNm": "노루홀딩스1우선주",
+    "itmsNm": "노루홀딩스우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000320",
+    "fullNm": "노루홀딩스보통주",
+    "itmsNm": "노루홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "194700",
+    "fullNm": "노바렉스",
+    "itmsNm": "노바렉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "285490",
+    "fullNm": "노바텍",
+    "itmsNm": "노바텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "229500",
+    "fullNm": "노브메타파마",
+    "itmsNm": "노브메타파마",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "106520",
+    "fullNm": "노블엠앤비",
+    "itmsNm": "노블엠앤비",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "376930",
+    "fullNm": "노을",
+    "itmsNm": "노을",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "278650",
+    "fullNm": "노터스",
+    "itmsNm": "노터스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006280",
+    "fullNm": "녹십자보통주",
+    "itmsNm": "녹십자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "142280",
+    "fullNm": "녹십자엠에스",
+    "itmsNm": "녹십자엠에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "234690",
+    "fullNm": "녹십자웰빙",
+    "itmsNm": "녹십자웰빙",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005257",
+    "fullNm": "녹십자홀딩스2우선주(신형)",
+    "itmsNm": "녹십자홀딩스2우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005250",
+    "fullNm": "녹십자홀딩스보통주",
+    "itmsNm": "녹십자홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "065560",
+    "fullNm": "녹원씨엔아이",
+    "itmsNm": "녹원씨엔아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004370",
+    "fullNm": "농심보통주",
+    "itmsNm": "농심",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "072710",
+    "fullNm": "농심홀딩스보통주",
+    "itmsNm": "농심홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "154030",
+    "fullNm": "농업회사법인 아시아종묘",
+    "itmsNm": "아시아종묘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054050",
+    "fullNm": "농업회사법인농우바이오",
+    "itmsNm": "농우바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "069140",
+    "fullNm": "누리플랜",
+    "itmsNm": "누리플랜",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "040160",
+    "fullNm": "누리플렉스",
+    "itmsNm": "누리플렉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "332290",
+    "fullNm": "누보",
+    "itmsNm": "누보",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "348340",
+    "fullNm": "뉴로메카",
+    "itmsNm": "뉴로메카",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060260",
+    "fullNm": "뉴보텍",
+    "itmsNm": "뉴보텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "012340",
+    "fullNm": "뉴인텍",
+    "itmsNm": "뉴인텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214870",
+    "fullNm": "뉴지랩파마",
+    "itmsNm": "뉴지랩파마",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "270870",
+    "fullNm": "뉴트리",
+    "itmsNm": "뉴트리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "144960",
+    "fullNm": "뉴파워프라즈마",
+    "itmsNm": "뉴파워프라즈마",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "085670",
+    "fullNm": "뉴프렉스",
+    "itmsNm": "뉴프렉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "064260",
+    "fullNm": "다날",
+    "itmsNm": "다날",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "093640",
+    "fullNm": "다믈멀티미디어",
+    "itmsNm": "다믈멀티미디어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "340360",
+    "fullNm": "다보링크",
+    "itmsNm": "다보링크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039560",
+    "fullNm": "다산네트웍스",
+    "itmsNm": "다산네트웍스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "058730",
+    "fullNm": "다스코보통주",
+    "itmsNm": "다스코",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "298870",
+    "fullNm": "다올인베스트먼트",
+    "itmsNm": "다올인베스트먼트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "030210",
+    "fullNm": "다올투자증권보통주",
+    "itmsNm": "다올투자증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "023590",
+    "fullNm": "다우기술보통주",
+    "itmsNm": "다우기술",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "032190",
+    "fullNm": "다우데이타",
+    "itmsNm": "다우데이타",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "323350",
+    "fullNm": "다원넥스뷰",
+    "itmsNm": "다원넥스뷰",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "068240",
+    "fullNm": "다원시스",
+    "itmsNm": "다원시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "145210",
+    "fullNm": "다이나믹디자인보통주",
+    "itmsNm": "다이나믹디자인",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "271850",
+    "fullNm": "다이오진",
+    "itmsNm": "다이오진",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "019680",
+    "fullNm": "대교보통주",
+    "itmsNm": "대교",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "019685",
+    "fullNm": "대교우선주(신형)",
+    "itmsNm": "대교우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006370",
+    "fullNm": "대구백화점보통주",
+    "itmsNm": "대구백화점",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "00806K",
+    "fullNm": "대덕1우선주",
+    "itmsNm": "대덕1우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "008060",
+    "fullNm": "대덕보통주",
+    "itmsNm": "대덕",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "353200",
+    "fullNm": "대덕전자보통주",
+    "itmsNm": "대덕전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "35320K",
+    "fullNm": "대덕전자우선주",
+    "itmsNm": "대덕전자1우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "178600",
+    "fullNm": "대동고려삼 주식회사",
+    "itmsNm": "대동고려삼",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "020400",
+    "fullNm": "대동금속",
+    "itmsNm": "대동금속",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "008830",
+    "fullNm": "대동기어",
+    "itmsNm": "대동기어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000490",
+    "fullNm": "대동보통주",
+    "itmsNm": "대동",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "048470",
+    "fullNm": "대동스틸",
+    "itmsNm": "대동스틸",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "008110",
+    "fullNm": "대동전자보통주",
+    "itmsNm": "대동전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004780",
+    "fullNm": "대륙제관",
+    "itmsNm": "대륙제관",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005750",
+    "fullNm": "대림B&Co보통주",
+    "itmsNm": "대림B&Co",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "017650",
+    "fullNm": "대림제지",
+    "itmsNm": "대림제지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006570",
+    "fullNm": "대림통상보통주",
+    "itmsNm": "대림통상",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007720",
+    "fullNm": "대명소노시즌",
+    "itmsNm": "대명소노시즌",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "389260",
+    "fullNm": "대명에너지",
+    "itmsNm": "대명에너지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "317850",
+    "fullNm": "대모엔지니어링",
+    "itmsNm": "대모",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "290670",
+    "fullNm": "대보마그네틱",
+    "itmsNm": "대보마그네틱",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078140",
+    "fullNm": "대봉엘에스",
+    "itmsNm": "대봉엘에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001685",
+    "fullNm": "대상1우선주",
+    "itmsNm": "대상우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001680",
+    "fullNm": "대상보통주",
+    "itmsNm": "대상",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "084695",
+    "fullNm": "대상홀딩스 1우선주",
+    "itmsNm": "대상홀딩스우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "084690",
+    "fullNm": "대상홀딩스 보통주",
+    "itmsNm": "대상홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "036480",
+    "fullNm": "대성미생물연구소",
+    "itmsNm": "대성미생물",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "128820",
+    "fullNm": "대성산업보통주",
+    "itmsNm": "대성산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "117580",
+    "fullNm": "대성에너지보통주",
+    "itmsNm": "대성에너지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "025440",
+    "fullNm": "대성엘텍",
+    "itmsNm": "대성엘텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "027830",
+    "fullNm": "대성창업투자",
+    "itmsNm": "대성창투",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "104040",
+    "fullNm": "대성파인텍",
+    "itmsNm": "대성파인텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "129920",
+    "fullNm": "대성하이텍",
+    "itmsNm": "대성하이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "016710",
+    "fullNm": "대성홀딩스보통주",
+    "itmsNm": "대성홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "387310",
+    "fullNm": "대신밸런스제10호기업인수목적",
+    "itmsNm": "대신밸런스제10호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "397500",
+    "fullNm": "대신밸런스제11호기업인수목적",
+    "itmsNm": "대신밸런스제11호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "426670",
+    "fullNm": "대신밸런스제12호기업인수목적",
+    "itmsNm": "대신밸런스제12호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "438220",
+    "fullNm": "대신밸런스제13호기업인수목적",
+    "itmsNm": "대신밸런스제13호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "442310",
+    "fullNm": "대신밸런스제14호기업인수목적",
+    "itmsNm": "대신밸런스제14호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "020180",
+    "fullNm": "대신정보통신",
+    "itmsNm": "대신정보통신",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003545",
+    "fullNm": "대신증권1우선주",
+    "itmsNm": "대신증권우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003547",
+    "fullNm": "대신증권2우선주(신형)",
+    "itmsNm": "대신증권2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003540",
+    "fullNm": "대신증권보통주",
+    "itmsNm": "대신증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "045390",
+    "fullNm": "대아티아이",
+    "itmsNm": "대아티아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009190",
+    "fullNm": "대양금속보통주",
+    "itmsNm": "대양금속",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "108380",
+    "fullNm": "대양전기공업",
+    "itmsNm": "대양전기공업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006580",
+    "fullNm": "대양제지공업",
+    "itmsNm": "대양제지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "014160",
+    "fullNm": "대영포장보통주",
+    "itmsNm": "대영포장",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "047040",
+    "fullNm": "대우건설보통주",
+    "itmsNm": "대우건설",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009320",
+    "fullNm": "대우전자부품보통주",
+    "itmsNm": "대우부품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "042660",
+    "fullNm": "대우조선해양보통주",
+    "itmsNm": "대우조선해양",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003090",
+    "fullNm": "대웅보통주",
+    "itmsNm": "대웅",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "069620",
+    "fullNm": "대웅제약보통주",
+    "itmsNm": "대웅제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007680",
+    "fullNm": "대원",
+    "itmsNm": "대원",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000430",
+    "fullNm": "대원강업보통주",
+    "itmsNm": "대원강업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "048910",
+    "fullNm": "대원미디어",
+    "itmsNm": "대원미디어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005710",
+    "fullNm": "대원산업",
+    "itmsNm": "대원산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006345",
+    "fullNm": "대원전선1우선주",
+    "itmsNm": "대원전선우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006340",
+    "fullNm": "대원전선보통주",
+    "itmsNm": "대원전선",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003220",
+    "fullNm": "대원제약보통주",
+    "itmsNm": "대원제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "024890",
+    "fullNm": "대원화성보통주",
+    "itmsNm": "대원화성",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "290380",
+    "fullNm": "대유",
+    "itmsNm": "대유",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002880",
+    "fullNm": "대유에이텍",
+    "itmsNm": "대유에이텍",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "290120",
+    "fullNm": "대유에이피",
+    "itmsNm": "대유에이피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000300",
+    "fullNm": "대유플러스보통주",
+    "itmsNm": "대유플러스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "120240",
+    "fullNm": "대정화금",
+    "itmsNm": "대정화금",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003310",
+    "fullNm": "대주산업",
+    "itmsNm": "대주산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "114920",
+    "fullNm": "대주이엔티 주식회사",
+    "itmsNm": "대주이엔티",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "078600",
+    "fullNm": "대주전자재료",
+    "itmsNm": "대주전자재료",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "015230",
+    "fullNm": "대창단조보통주",
+    "itmsNm": "대창단조",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012800",
+    "fullNm": "대창보통주",
+    "itmsNm": "대창",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "096350",
+    "fullNm": "대창솔루션",
+    "itmsNm": "대창솔루션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "140520",
+    "fullNm": "대창스틸",
+    "itmsNm": "대창스틸",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "131220",
+    "fullNm": "대한과학",
+    "itmsNm": "대한과학",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010170",
+    "fullNm": "대한광통신",
+    "itmsNm": "대한광통신",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060900",
+    "fullNm": "대한그린파워",
+    "itmsNm": "대한그린파워",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054670",
+    "fullNm": "대한뉴팜",
+    "itmsNm": "대한뉴팜",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001070",
+    "fullNm": "대한방직보통주",
+    "itmsNm": "대한방직",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "023910",
+    "fullNm": "대한약품공업",
+    "itmsNm": "대한약품",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006650",
+    "fullNm": "대한유화보통주",
+    "itmsNm": "대한유화",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001440",
+    "fullNm": "대한전선보통주",
+    "itmsNm": "대한전선",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "084010",
+    "fullNm": "대한제강 보통주",
+    "itmsNm": "대한제강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001795",
+    "fullNm": "대한제당1우선주",
+    "itmsNm": "대한제당우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001790",
+    "fullNm": "대한제당보통주",
+    "itmsNm": "대한제당",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001130",
+    "fullNm": "대한제분보통주",
+    "itmsNm": "대한제분",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003495",
+    "fullNm": "대한항공1우선주",
+    "itmsNm": "대한항공우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003490",
+    "fullNm": "대한항공보통주",
+    "itmsNm": "대한항공",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005880",
+    "fullNm": "대한해운보통주",
+    "itmsNm": "대한해운",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003830",
+    "fullNm": "대한화섬보통주",
+    "itmsNm": "대한화섬",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "016090",
+    "fullNm": "대현보통주",
+    "itmsNm": "대현",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "069460",
+    "fullNm": "대호에이엘보통주",
+    "itmsNm": "대호에이엘",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "021040",
+    "fullNm": "대호특수강",
+    "itmsNm": "대호특수강",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "021045",
+    "fullNm": "대호특수강1우선주",
+    "itmsNm": "대호특수강우",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "067080",
+    "fullNm": "대화제약",
+    "itmsNm": "대화제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "161570",
+    "fullNm": "더 미동",
+    "itmsNm": "THE MIDONG",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "298540",
+    "fullNm": "더네이쳐홀딩스",
+    "itmsNm": "더네이쳐홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "192080",
+    "fullNm": "더블유게임즈보통주",
+    "itmsNm": "더블유게임즈",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "393890",
+    "fullNm": "더블유씨피",
+    "itmsNm": "더블유씨피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "299170",
+    "fullNm": "더블유에스아이",
+    "itmsNm": "더블유에스아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "089230",
+    "fullNm": "더이앤엠",
+    "itmsNm": "THE E&M",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "012510",
+    "fullNm": "더존비즈온보통주",
+    "itmsNm": "더존비즈온",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "224060",
+    "fullNm": "더코디",
+    "itmsNm": "더코디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "302920",
+    "fullNm": "더콘텐츠온",
+    "itmsNm": "더콘텐츠온",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "213420",
+    "fullNm": "덕산네오룩스",
+    "itmsNm": "덕산네오룩스",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "317330",
+    "fullNm": "덕산테코피아",
+    "itmsNm": "덕산테코피아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "077360",
+    "fullNm": "덕산하이메탈",
+    "itmsNm": "덕산하이메탈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004835",
+    "fullNm": "덕성1우선주",
+    "itmsNm": "덕성우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004830",
+    "fullNm": "덕성보통주",
+    "itmsNm": "덕성",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "090410",
+    "fullNm": "덕신하우징",
+    "itmsNm": "덕신하우징",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "024900",
+    "fullNm": "덕양산업보통주",
+    "itmsNm": "덕양산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "263600",
+    "fullNm": "덕우전자",
+    "itmsNm": "덕우전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "194480",
+    "fullNm": "데브시스터즈",
+    "itmsNm": "데브시스터즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "348840",
+    "fullNm": "데이드림엔터테인먼트",
+    "itmsNm": "데이드림엔터",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "263800",
+    "fullNm": "데이타솔루션",
+    "itmsNm": "데이타솔루션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "199150",
+    "fullNm": "데이터스트림즈",
+    "itmsNm": "데이터스트림즈",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "206560",
+    "fullNm": "덱스터스튜디오",
+    "itmsNm": "덱스터",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "261200",
+    "fullNm": "덴티스",
+    "itmsNm": "덴티스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "145720",
+    "fullNm": "덴티움보통주",
+    "itmsNm": "덴티움",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "227420",
+    "fullNm": "도부마스크",
+    "itmsNm": "도부마스크",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "067990",
+    "fullNm": "도이치모터스",
+    "itmsNm": "도이치모터스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002150",
+    "fullNm": "도화엔지니어링보통주",
+    "itmsNm": "도화엔지니어링",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006620",
+    "fullNm": "동구바이오제약",
+    "itmsNm": "동구바이오제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005160",
+    "fullNm": "동국산업",
+    "itmsNm": "동국산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "075970",
+    "fullNm": "동국알앤에스",
+    "itmsNm": "동국알앤에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "100130",
+    "fullNm": "동국에스엔씨",
+    "itmsNm": "동국S&C",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001230",
+    "fullNm": "동국제강보통주",
+    "itmsNm": "동국제강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "086450",
+    "fullNm": "동국제약",
+    "itmsNm": "동국제약",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "004140",
+    "fullNm": "동방보통주",
+    "itmsNm": "동방",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "099410",
+    "fullNm": "동방선기",
+    "itmsNm": "동방선기",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007590",
+    "fullNm": "동방아그로보통주",
+    "itmsNm": "동방아그로",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005965",
+    "fullNm": "동부건설1우선주",
+    "itmsNm": "동부건설우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005960",
+    "fullNm": "동부건설보통주",
+    "itmsNm": "동부건설",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "026960",
+    "fullNm": "동서보통주",
+    "itmsNm": "동서",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002210",
+    "fullNm": "동성제약보통주",
+    "itmsNm": "동성제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "102260",
+    "fullNm": "동성케미컬보통주",
+    "itmsNm": "동성케미컬",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "033500",
+    "fullNm": "동성화인텍",
+    "itmsNm": "동성화인텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "025950",
+    "fullNm": "동신건설",
+    "itmsNm": "동신건설",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000640",
+    "fullNm": "동아쏘시오홀딩스보통주",
+    "itmsNm": "동아쏘시오홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "170900",
+    "fullNm": "동아에스티보통주",
+    "itmsNm": "동아에스티",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "088130",
+    "fullNm": "동아엘텍",
+    "itmsNm": "동아엘텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "028100",
+    "fullNm": "동아지질보통주",
+    "itmsNm": "동아지질",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "282690",
+    "fullNm": "동아타이어공업보통주",
+    "itmsNm": "동아타이어",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "041930",
+    "fullNm": "동아화성",
+    "itmsNm": "동아화성",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001525",
+    "fullNm": "동양1우선주",
+    "itmsNm": "동양우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001527",
+    "fullNm": "동양2우선주(신형)",
+    "itmsNm": "동양2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "084670",
+    "fullNm": "동양고속보통주",
+    "itmsNm": "동양고속",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001520",
+    "fullNm": "동양보통주",
+    "itmsNm": "동양",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "082640",
+    "fullNm": "동양생명보험보통주",
+    "itmsNm": "동양생명",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "060380",
+    "fullNm": "동양에스텍",
+    "itmsNm": "동양에스텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "079960",
+    "fullNm": "동양이엔피",
+    "itmsNm": "동양이엔피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "008970",
+    "fullNm": "동양철관보통주",
+    "itmsNm": "동양철관",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "228340",
+    "fullNm": "동양파일",
+    "itmsNm": "동양파일",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092780",
+    "fullNm": "동양피스톤보통주",
+    "itmsNm": "동양피스톤",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "088910",
+    "fullNm": "동우팜투테이블",
+    "itmsNm": "동우팜투테이블",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "094170",
+    "fullNm": "동운아나텍",
+    "itmsNm": "동운아나텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049770",
+    "fullNm": "동원F&B보통주",
+    "itmsNm": "동원F&B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "013120",
+    "fullNm": "동원개발",
+    "itmsNm": "동원개발",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "018500",
+    "fullNm": "동원금속보통주",
+    "itmsNm": "동원금속",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006040",
+    "fullNm": "동원산업보통주",
+    "itmsNm": "동원산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "030720",
+    "fullNm": "동원수산보통주",
+    "itmsNm": "동원수산",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "014825",
+    "fullNm": "동원시스템즈1우선주",
+    "itmsNm": "동원시스템즈우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "014820",
+    "fullNm": "동원시스템즈보통주",
+    "itmsNm": "동원시스템즈",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "163560",
+    "fullNm": "동일고무벨트보통주",
+    "itmsNm": "동일고무벨트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "109860",
+    "fullNm": "동일금속",
+    "itmsNm": "동일금속",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032960",
+    "fullNm": "동일기연",
+    "itmsNm": "동일기연",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004890",
+    "fullNm": "동일산업보통주",
+    "itmsNm": "동일산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002690",
+    "fullNm": "동일제강보통주",
+    "itmsNm": "동일제강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "023790",
+    "fullNm": "동일철강",
+    "itmsNm": "동일철강",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005290",
+    "fullNm": "동진쎄미켐",
+    "itmsNm": "동진쎄미켐",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "025900",
+    "fullNm": "동화기업",
+    "itmsNm": "동화기업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000020",
+    "fullNm": "동화약품보통주",
+    "itmsNm": "동화약품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000155",
+    "fullNm": "두산1우선주",
+    "itmsNm": "두산우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000157",
+    "fullNm": "두산2우선주(신형)",
+    "itmsNm": "두산2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "241560",
+    "fullNm": "두산밥캣보통주",
+    "itmsNm": "두산밥캣",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000150",
+    "fullNm": "두산보통주",
+    "itmsNm": "두산",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "034020",
+    "fullNm": "두산에너빌리티보통주",
+    "itmsNm": "두산에너빌리티",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "131970",
+    "fullNm": "두산테스나",
+    "itmsNm": "두산테스나",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "33626K",
+    "fullNm": "두산퓨얼셀1우선주",
+    "itmsNm": "두산퓨얼셀1우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "33626L",
+    "fullNm": "두산퓨얼셀2우선주(신형)",
+    "itmsNm": "두산퓨얼셀2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "336260",
+    "fullNm": "두산퓨얼셀보통주",
+    "itmsNm": "두산퓨얼셀",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "016740",
+    "fullNm": "두올보통주",
+    "itmsNm": "두올",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "073190",
+    "fullNm": "듀오백",
+    "itmsNm": "듀오백",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "176750",
+    "fullNm": "듀켐바이오",
+    "itmsNm": "듀켐바이오",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "030350",
+    "fullNm": "드래곤플라이",
+    "itmsNm": "드래곤플라이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "203650",
+    "fullNm": "드림시큐리티",
+    "itmsNm": "드림시큐리티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "223250",
+    "fullNm": "드림씨아이에스",
+    "itmsNm": "드림씨아이에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060570",
+    "fullNm": "드림어스컴퍼니",
+    "itmsNm": "드림어스컴퍼니",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "192650",
+    "fullNm": "드림텍보통주",
+    "itmsNm": "드림텍",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "217620",
+    "fullNm": "디딤이앤에프",
+    "itmsNm": "디딤이앤에프",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "016670",
+    "fullNm": "디모아",
+    "itmsNm": "디모아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "187870",
+    "fullNm": "디바이스이엔지",
+    "itmsNm": "디바이스이엔지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "404950",
+    "fullNm": "디비금융제10호기업인수목적",
+    "itmsNm": "DB금융스팩10호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "367340",
+    "fullNm": "디비금융제8호기업인수목적",
+    "itmsNm": "DB금융스팩8호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "367360",
+    "fullNm": "디비금융제9호기업인수목적",
+    "itmsNm": "DB금융스팩9호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066670",
+    "fullNm": "디스플레이테크",
+    "itmsNm": "디스플레이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "024090",
+    "fullNm": "디씨엠보통주",
+    "itmsNm": "디씨엠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003160",
+    "fullNm": "디아이보통주",
+    "itmsNm": "디아이",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "092200",
+    "fullNm": "디아이씨 보통주",
+    "itmsNm": "디아이씨",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "110990",
+    "fullNm": "디아이티",
+    "itmsNm": "디아이티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078590",
+    "fullNm": "디아크",
+    "itmsNm": "디아크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004840",
+    "fullNm": "디알비동일보통주",
+    "itmsNm": "DRB동일",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "263690",
+    "fullNm": "디알젬",
+    "itmsNm": "디알젬",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214680",
+    "fullNm": "디알텍",
+    "itmsNm": "디알텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "377190",
+    "fullNm": "디앤디플랫폼리츠보통주",
+    "itmsNm": "디앤디플랫폼리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "263720",
+    "fullNm": "디앤씨미디어",
+    "itmsNm": "디앤씨미디어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "376300",
+    "fullNm": "디어유",
+    "itmsNm": "디어유",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "241520",
+    "fullNm": "디에스씨인베스트먼트",
+    "itmsNm": "DSC인베스트먼트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "141020",
+    "fullNm": "디에스앤엘",
+    "itmsNm": "디에스앤엘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "109740",
+    "fullNm": "디에스케이",
+    "itmsNm": "디에스케이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "196490",
+    "fullNm": "디에이테크놀로지",
+    "itmsNm": "디에이테크놀로지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066900",
+    "fullNm": "디에이피",
+    "itmsNm": "디에이피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "180400",
+    "fullNm": "디엑스앤브이엑스",
+    "itmsNm": "DXVX",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "127120",
+    "fullNm": "디엔에이링크",
+    "itmsNm": "디엔에이링크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092070",
+    "fullNm": "디엔에프",
+    "itmsNm": "디엔에프",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007340",
+    "fullNm": "디엔오토모티브보통주",
+    "itmsNm": "DN오토모티브",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "068790",
+    "fullNm": "디엠에스",
+    "itmsNm": "DMS",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039840",
+    "fullNm": "디오",
+    "itmsNm": "디오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "219550",
+    "fullNm": "디와이디",
+    "itmsNm": "디와이디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "013570",
+    "fullNm": "디와이보통주",
+    "itmsNm": "디와이",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "310870",
+    "fullNm": "디와이씨",
+    "itmsNm": "디와이씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "210540",
+    "fullNm": "디와이파워보통주",
+    "itmsNm": "디와이파워",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "104460",
+    "fullNm": "디와이피엔에프",
+    "itmsNm": "디와이피엔에프",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "079810",
+    "fullNm": "디이엔티",
+    "itmsNm": "디이엔티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "113810",
+    "fullNm": "디젠스",
+    "itmsNm": "디젠스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "043360",
+    "fullNm": "디지아이",
+    "itmsNm": "디지아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "197140",
+    "fullNm": "디지캡",
+    "itmsNm": "디지캡",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "068930",
+    "fullNm": "디지털대성",
+    "itmsNm": "디지털대성",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033130",
+    "fullNm": "디지틀조선일보",
+    "itmsNm": "디지틀조선",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "105740",
+    "fullNm": "디케이락",
+    "itmsNm": "디케이락",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "263020",
+    "fullNm": "디케이앤디",
+    "itmsNm": "디케이앤디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "290550",
+    "fullNm": "디케이티",
+    "itmsNm": "디케이티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "187220",
+    "fullNm": "디티앤씨",
+    "itmsNm": "디티앤씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "383930",
+    "fullNm": "디티앤씨알오",
+    "itmsNm": "디티앤씨알오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "163430",
+    "fullNm": "디피코",
+    "itmsNm": "디피코",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "131180",
+    "fullNm": "딜리",
+    "itmsNm": "딜리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "315640",
+    "fullNm": "딥노이드",
+    "itmsNm": "딥노이드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "317120",
+    "fullNm": "라닉스",
+    "itmsNm": "라닉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "042510",
+    "fullNm": "라온시큐어",
+    "itmsNm": "라온시큐어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "232680",
+    "fullNm": "라온테크",
+    "itmsNm": "라온테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "300120",
+    "fullNm": "라온피플",
+    "itmsNm": "라온피플",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "171120",
+    "fullNm": "라이온켐텍",
+    "itmsNm": "라이온켐텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "069540",
+    "fullNm": "라이트론",
+    "itmsNm": "라이트론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "285770",
+    "fullNm": "라이프사이언스테크놀로지",
+    "itmsNm": "라이프사이언스테크놀로지",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "347700",
+    "fullNm": "라이프시맨틱스",
+    "itmsNm": "라이프시맨틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214260",
+    "fullNm": "라파스",
+    "itmsNm": "라파스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "403360",
+    "fullNm": "라피치",
+    "itmsNm": "라피치",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "115390",
+    "fullNm": "락앤락보통주",
+    "itmsNm": "락앤락",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "200350",
+    "fullNm": "래몽래인",
+    "itmsNm": "래몽래인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "171010",
+    "fullNm": "램테크놀러지",
+    "itmsNm": "램테크놀러지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "084650",
+    "fullNm": "랩지노믹스",
+    "itmsNm": "랩지노믹스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "217500",
+    "fullNm": "러셀",
+    "itmsNm": "러셀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092590",
+    "fullNm": "럭스피아",
+    "itmsNm": "럭스피아",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "141080",
+    "fullNm": "레고켐바이오사이언스",
+    "itmsNm": "레고켐바이오",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "038390",
+    "fullNm": "레드캡투어",
+    "itmsNm": "레드캡투어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "294140",
+    "fullNm": "레몬",
+    "itmsNm": "레몬",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "228670",
+    "fullNm": "레이",
+    "itmsNm": "레이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "228850",
+    "fullNm": "레이언스",
+    "itmsNm": "레이언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "412350",
+    "fullNm": "레이저쎌",
+    "itmsNm": "레이저쎌",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "281740",
+    "fullNm": "레이크머티리얼즈",
+    "itmsNm": "레이크머티리얼즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "277810",
+    "fullNm": "레인보우로보틱스",
+    "itmsNm": "레인보우로보틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "179720",
+    "fullNm": "렌딩머신",
+    "itmsNm": "렌딩머신",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "215100",
+    "fullNm": "로보로보",
+    "itmsNm": "로보로보",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "090360",
+    "fullNm": "로보스타",
+    "itmsNm": "로보스타",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "238500",
+    "fullNm": "로보쓰리",
+    "itmsNm": "로보쓰리",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "108490",
+    "fullNm": "로보티즈",
+    "itmsNm": "로보티즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "900260",
+    "fullNm": "로스웰인터내셔널",
+    "itmsNm": "로스웰",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "223220",
+    "fullNm": "로지스몬",
+    "itmsNm": "로지스몬",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "067730",
+    "fullNm": "로지시스",
+    "itmsNm": "로지시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "071280",
+    "fullNm": "로체시스템즈",
+    "itmsNm": "로체시스템즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032350",
+    "fullNm": "롯데관광개발 보통주",
+    "itmsNm": "롯데관광개발",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "089860",
+    "fullNm": "롯데렌탈보통주",
+    "itmsNm": "롯데렌탈",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "330590",
+    "fullNm": "롯데리츠보통주",
+    "itmsNm": "롯데리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000400",
+    "fullNm": "롯데손해보험보통주",
+    "itmsNm": "롯데손해보험",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "023530",
+    "fullNm": "롯데쇼핑 보통주",
+    "itmsNm": "롯데쇼핑",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004000",
+    "fullNm": "롯데정밀화학보통주",
+    "itmsNm": "롯데정밀화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "286940",
+    "fullNm": "롯데정보통신보통주",
+    "itmsNm": "롯데정보통신",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "280360",
+    "fullNm": "롯데제과보통주",
+    "itmsNm": "롯데제과",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "00499K",
+    "fullNm": "롯데지주1우선주",
+    "itmsNm": "롯데지주우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004990",
+    "fullNm": "롯데지주보통주",
+    "itmsNm": "롯데지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005305",
+    "fullNm": "롯데칠성음료1우선주",
+    "itmsNm": "롯데칠성우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005300",
+    "fullNm": "롯데칠성음료보통주",
+    "itmsNm": "롯데칠성",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011170",
+    "fullNm": "롯데케미칼보통주",
+    "itmsNm": "롯데케미칼",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "071840",
+    "fullNm": "롯데하이마트보통주",
+    "itmsNm": "롯데하이마트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "328130",
+    "fullNm": "루닛",
+    "itmsNm": "루닛",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038060",
+    "fullNm": "루멘스",
+    "itmsNm": "루멘스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "162120",
+    "fullNm": "루켄테크놀러지스",
+    "itmsNm": "루켄테크놀러지스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "253610",
+    "fullNm": "루트락",
+    "itmsNm": "루트락",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "085370",
+    "fullNm": "루트로닉",
+    "itmsNm": "루트로닉",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "08537M",
+    "fullNm": "루트로닉3우선주(전환)",
+    "itmsNm": "루트로닉3우C",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060240",
+    "fullNm": "룽투코리아",
+    "itmsNm": "룽투코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "058470",
+    "fullNm": "리노공업",
+    "itmsNm": "리노공업",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "039980",
+    "fullNm": "리노스",
+    "itmsNm": "리노스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "019570",
+    "fullNm": "리더스 기술투자",
+    "itmsNm": "리더스 기술투자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "016100",
+    "fullNm": "리더스코스메틱",
+    "itmsNm": "리더스코스메틱",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "012700",
+    "fullNm": "리드코프",
+    "itmsNm": "리드코프",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "302550",
+    "fullNm": "리메드",
+    "itmsNm": "리메드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "377450",
+    "fullNm": "리파인",
+    "itmsNm": "리파인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "277070",
+    "fullNm": "린드먼아시아인베스트먼트",
+    "itmsNm": "린드먼아시아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "042500",
+    "fullNm": "링네트",
+    "itmsNm": "링네트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "219420",
+    "fullNm": "링크제니시스",
+    "itmsNm": "링크제니시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "027740",
+    "fullNm": "마니커보통주",
+    "itmsNm": "마니커",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "195500",
+    "fullNm": "마니커에프앤지",
+    "itmsNm": "마니커에프앤지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "357430",
+    "fullNm": "마스턴프리미어리츠보통주",
+    "itmsNm": "마스턴프리미어리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "305090",
+    "fullNm": "마이크로디지탈",
+    "itmsNm": "마이크로디지탈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "448780",
+    "fullNm": "마이크로엔엑스",
+    "itmsNm": "마이크로엔엑스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "147760",
+    "fullNm": "마이크로프랜드",
+    "itmsNm": "마이크로프랜드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "377480",
+    "fullNm": "마인즈랩",
+    "itmsNm": "마인즈랩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "169330",
+    "fullNm": "마크로밀엠브레인",
+    "itmsNm": "엠브레인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038290",
+    "fullNm": "마크로젠",
+    "itmsNm": "마크로젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001080",
+    "fullNm": "만호제강보통주",
+    "itmsNm": "만호제강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "267980",
+    "fullNm": "매일유업",
+    "itmsNm": "매일유업",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "005990",
+    "fullNm": "매일홀딩스",
+    "itmsNm": "매일홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "093520",
+    "fullNm": "매커스",
+    "itmsNm": "매커스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "377030",
+    "fullNm": "맥스트",
+    "itmsNm": "맥스트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "088980",
+    "fullNm": "맥쿼리한국인프라투융자회사 보통주",
+    "itmsNm": "맥쿼리인프라",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "100590",
+    "fullNm": "머큐리",
+    "itmsNm": "머큐리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "067280",
+    "fullNm": "멀티캠퍼스",
+    "itmsNm": "멀티캠퍼스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "072870",
+    "fullNm": "메가스터디",
+    "itmsNm": "메가스터디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "215200",
+    "fullNm": "메가스터디교육",
+    "itmsNm": "메가스터디교육",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "133750",
+    "fullNm": "메가엠디",
+    "itmsNm": "메가엠디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "235980",
+    "fullNm": "메드팩토",
+    "itmsNm": "메드팩토",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "200580",
+    "fullNm": "메디쎄이",
+    "itmsNm": "메디쎄이",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "041920",
+    "fullNm": "메디아나",
+    "itmsNm": "메디아나",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "233250",
+    "fullNm": "메디안디노스틱",
+    "itmsNm": "메디안디노스틱",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "014100",
+    "fullNm": "메디앙스",
+    "itmsNm": "메디앙스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "236340",
+    "fullNm": "메디젠휴먼케어",
+    "itmsNm": "메디젠휴먼케어",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "054180",
+    "fullNm": "메디콕스",
+    "itmsNm": "메디콕스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "086900",
+    "fullNm": "메디톡스",
+    "itmsNm": "메디톡스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078160",
+    "fullNm": "메디포스트",
+    "itmsNm": "메디포스트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065650",
+    "fullNm": "메디프론디비티",
+    "itmsNm": "메디프론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "138040",
+    "fullNm": "메리츠금융지주회사보통주",
+    "itmsNm": "메리츠금융지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "008560",
+    "fullNm": "메리츠증권보통주",
+    "itmsNm": "메리츠증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000060",
+    "fullNm": "메리츠화재해상보험보통주",
+    "itmsNm": "메리츠화재",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "021880",
+    "fullNm": "메이슨캐피탈",
+    "itmsNm": "메이슨캐피탈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "140410",
+    "fullNm": "메지온",
+    "itmsNm": "메지온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "241770",
+    "fullNm": "메카로",
+    "itmsNm": "메카로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "090370",
+    "fullNm": "메타랩스보통주",
+    "itmsNm": "메타랩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "059210",
+    "fullNm": "메타바이오메드",
+    "itmsNm": "메타바이오메드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "058110",
+    "fullNm": "멕아이씨에스",
+    "itmsNm": "멕아이씨에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "096640",
+    "fullNm": "멜파스",
+    "itmsNm": "멜파스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "017180",
+    "fullNm": "명문제약 보통주",
+    "itmsNm": "명문제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "257370",
+    "fullNm": "명성티엔에스",
+    "itmsNm": "명성티엔에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009900",
+    "fullNm": "명신산업보통주",
+    "itmsNm": "명신산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "267060",
+    "fullNm": "명진홀딩스",
+    "itmsNm": "명진홀딩스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "012690",
+    "fullNm": "모나리자보통주",
+    "itmsNm": "모나리자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005360",
+    "fullNm": "모나미보통주",
+    "itmsNm": "모나미",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "080420",
+    "fullNm": "모다이노칩",
+    "itmsNm": "모다이노칩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "417970",
+    "fullNm": "모델솔루션",
+    "itmsNm": "모델솔루션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "080160",
+    "fullNm": "모두투어네트워크",
+    "itmsNm": "모두투어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "204210",
+    "fullNm": "모두투어리츠보통주",
+    "itmsNm": "모두투어리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "087260",
+    "fullNm": "모바일어플라이언스",
+    "itmsNm": "모바일어플라이언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101330",
+    "fullNm": "모베이스",
+    "itmsNm": "모베이스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "012860",
+    "fullNm": "모베이스전자",
+    "itmsNm": "모베이스전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "363260",
+    "fullNm": "모비데이즈",
+    "itmsNm": "모비데이즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "348030",
+    "fullNm": "모비릭스",
+    "itmsNm": "모비릭스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "250060",
+    "fullNm": "모비스",
+    "itmsNm": "모비스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "288980",
+    "fullNm": "모아데이타",
+    "itmsNm": "모아데이타",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033200",
+    "fullNm": "모아텍",
+    "itmsNm": "모아텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "333050",
+    "fullNm": "모코엠시스",
+    "itmsNm": "모코엠시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009680",
+    "fullNm": "모토닉보통주",
+    "itmsNm": "모토닉",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "118990",
+    "fullNm": "모트렉스",
+    "itmsNm": "모트렉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006920",
+    "fullNm": "모헨즈",
+    "itmsNm": "모헨즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001810",
+    "fullNm": "무림에스피",
+    "itmsNm": "무림SP",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009200",
+    "fullNm": "무림페이퍼보통주",
+    "itmsNm": "무림페이퍼",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009580",
+    "fullNm": "무림피앤피보통주",
+    "itmsNm": "무림P&P",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "135160",
+    "fullNm": "무송지오씨",
+    "itmsNm": "무송지오씨",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "322970",
+    "fullNm": "무진메디",
+    "itmsNm": "무진메디",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "033920",
+    "fullNm": "무학보통주",
+    "itmsNm": "무학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "008420",
+    "fullNm": "문배철강보통주",
+    "itmsNm": "문배철강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "279600",
+    "fullNm": "미디어젠",
+    "itmsNm": "미디어젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "095500",
+    "fullNm": "미래나노텍",
+    "itmsNm": "미래나노텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "025560",
+    "fullNm": "미래산업보통주",
+    "itmsNm": "미래산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "218150",
+    "fullNm": "미래생명자원",
+    "itmsNm": "미래생명자원",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007120",
+    "fullNm": "미래아이앤지보통주",
+    "itmsNm": "미래아이앤지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "396690",
+    "fullNm": "미래에셋글로벌리츠보통주",
+    "itmsNm": "미래에셋글로벌리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "353490",
+    "fullNm": "미래에셋대우기업인수목적 5호",
+    "itmsNm": "미래에셋대우스팩 5호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "357250",
+    "fullNm": "미래에셋맵스리츠보통주",
+    "itmsNm": "미래에셋맵스리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "094800",
+    "fullNm": "미래에셋맵스아시아퍼시픽부동산공모1호",
+    "itmsNm": "맵스리얼티1",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "100790",
+    "fullNm": "미래에셋벤처투자",
+    "itmsNm": "미래에셋벤처투자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "412930",
+    "fullNm": "미래에셋비전기업인수목적1호",
+    "itmsNm": "미래에셋비전스팩1호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "085620",
+    "fullNm": "미래에셋생명보험보통주",
+    "itmsNm": "미래에셋생명",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006805",
+    "fullNm": "미래에셋증권1우선주",
+    "itmsNm": "미래에셋증권우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "00680K",
+    "fullNm": "미래에셋증권2우선주(신형)",
+    "itmsNm": "미래에셋증권2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006800",
+    "fullNm": "미래에셋증권보통주",
+    "itmsNm": "미래에셋증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "208890",
+    "fullNm": "미래엔에듀파트너",
+    "itmsNm": "미래엔에듀파트너",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "049950",
+    "fullNm": "미래컴퍼니",
+    "itmsNm": "미래컴퍼니",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "207760",
+    "fullNm": "미스터블루",
+    "itmsNm": "미스터블루",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002840",
+    "fullNm": "미원상사보통주",
+    "itmsNm": "미원상사",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "268280",
+    "fullNm": "미원스페셜티케미칼보통주",
+    "itmsNm": "미원에스씨",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "107590",
+    "fullNm": "미원홀딩스 보통주",
+    "itmsNm": "미원홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "134380",
+    "fullNm": "미원화학보통주",
+    "itmsNm": "미원화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003650",
+    "fullNm": "미창석유공업보통주",
+    "itmsNm": "미창석유",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "059090",
+    "fullNm": "미코",
+    "itmsNm": "미코",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214610",
+    "fullNm": "미코바이오메드",
+    "itmsNm": "미코바이오메드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "201490",
+    "fullNm": "미투온",
+    "itmsNm": "미투온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "950190",
+    "fullNm": "미투젠",
+    "itmsNm": "미투젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "155900",
+    "fullNm": "바다로19호선박투자회사",
+    "itmsNm": "바다로19호",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "206640",
+    "fullNm": "바디텍메드",
+    "itmsNm": "바디텍메드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "018700",
+    "fullNm": "바른손",
+    "itmsNm": "바른손",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "035620",
+    "fullNm": "바른손이앤에이",
+    "itmsNm": "바른손이앤에이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "354390",
+    "fullNm": "바스칸바이오제약",
+    "itmsNm": "바스칸바이오제약",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "053030",
+    "fullNm": "바이넥스",
+    "itmsNm": "바이넥스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "301300",
+    "fullNm": "바이브컴퍼니",
+    "itmsNm": "바이브컴퍼니",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "377740",
+    "fullNm": "바이오노트보통주",
+    "itmsNm": "바이오노트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "064550",
+    "fullNm": "바이오니아",
+    "itmsNm": "바이오니아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "314930",
+    "fullNm": "바이오다인",
+    "itmsNm": "바이오다인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "208710",
+    "fullNm": "바이오로그디바이스",
+    "itmsNm": "바이오로그디바이스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "086820",
+    "fullNm": "바이오솔루션",
+    "itmsNm": "바이오솔루션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038460",
+    "fullNm": "바이오스마트",
+    "itmsNm": "바이오스마트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "281310",
+    "fullNm": "바이오시네틱스",
+    "itmsNm": "바이오시네틱스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "251120",
+    "fullNm": "바이오에프디엔씨",
+    "itmsNm": "바이오에프디엔씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "266470",
+    "fullNm": "바이오인프라생명과학",
+    "itmsNm": "바이오인프라생명과학",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "086040",
+    "fullNm": "바이오톡스텍",
+    "itmsNm": "바이오톡스텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "199290",
+    "fullNm": "바이오프로테크",
+    "itmsNm": "바이오프로테크",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "099430",
+    "fullNm": "바이오플러스",
+    "itmsNm": "바이오플러스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032980",
+    "fullNm": "바이온",
+    "itmsNm": "바이온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "222160",
+    "fullNm": "바이옵트로",
+    "itmsNm": "바이옵트로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "308080",
+    "fullNm": "바이젠셀",
+    "itmsNm": "바이젠셀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "043150",
+    "fullNm": "바텍",
+    "itmsNm": "바텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "323990",
+    "fullNm": "박셀바이오",
+    "itmsNm": "박셀바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003610",
+    "fullNm": "방림보통주",
+    "itmsNm": "방림",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "267790",
+    "fullNm": "배럴",
+    "itmsNm": "배럴",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001340",
+    "fullNm": "백광산업보통주",
+    "itmsNm": "백광산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "046310",
+    "fullNm": "백금티앤에이",
+    "itmsNm": "백금T&A",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "035150",
+    "fullNm": "백산보통주",
+    "itmsNm": "백산",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "331520",
+    "fullNm": "밸로프",
+    "itmsNm": "밸로프",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066410",
+    "fullNm": "버킷스튜디오",
+    "itmsNm": "버킷스튜디오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002410",
+    "fullNm": "범양건영보통주",
+    "itmsNm": "범양건영",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "382900",
+    "fullNm": "범한퓨얼셀",
+    "itmsNm": "범한퓨얼셀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "206400",
+    "fullNm": "베노홀딩스",
+    "itmsNm": "베노홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "019010",
+    "fullNm": "베뉴지",
+    "itmsNm": "베뉴지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "322190",
+    "fullNm": "베른",
+    "itmsNm": "베른",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "177350",
+    "fullNm": "베셀",
+    "itmsNm": "베셀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "299910",
+    "fullNm": "베스파",
+    "itmsNm": "베스파",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007210",
+    "fullNm": "벽산보통주",
+    "itmsNm": "벽산",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "225530",
+    "fullNm": "보광산업",
+    "itmsNm": "보광산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "250000",
+    "fullNm": "보라티알",
+    "itmsNm": "보라티알",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002760",
+    "fullNm": "보락보통주",
+    "itmsNm": "보락",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003850",
+    "fullNm": "보령보통주",
+    "itmsNm": "보령",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "310210",
+    "fullNm": "보로노이",
+    "itmsNm": "보로노이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006910",
+    "fullNm": "보성파워텍",
+    "itmsNm": "보성파워텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000890",
+    "fullNm": "보해양조보통주",
+    "itmsNm": "보해양조",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "226340",
+    "fullNm": "본느",
+    "itmsNm": "본느",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "206950",
+    "fullNm": "볼빅",
+    "itmsNm": "볼빅",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "008470",
+    "fullNm": "부-스타",
+    "itmsNm": "부스타",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003000",
+    "fullNm": "부광약품보통주",
+    "itmsNm": "부광약품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001275",
+    "fullNm": "부국증권1우선주",
+    "itmsNm": "부국증권우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001270",
+    "fullNm": "부국증권보통주",
+    "itmsNm": "부국증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "026940",
+    "fullNm": "부국철강 보통주",
+    "itmsNm": "부국철강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "014470",
+    "fullNm": "부방",
+    "itmsNm": "부방",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "011390",
+    "fullNm": "부산산업보통주",
+    "itmsNm": "부산산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005030",
+    "fullNm": "부산주공보통주",
+    "itmsNm": "부산주공",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "338220",
+    "fullNm": "뷰노",
+    "itmsNm": "뷰노",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "100120",
+    "fullNm": "뷰웍스",
+    "itmsNm": "뷰웍스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "337930",
+    "fullNm": "브랜드엑스코퍼레이션",
+    "itmsNm": "브랜드엑스코퍼레이션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "099390",
+    "fullNm": "브레인즈컴퍼니",
+    "itmsNm": "브레인즈컴퍼니",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "064480",
+    "fullNm": "브리지텍",
+    "itmsNm": "브리지텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "288330",
+    "fullNm": "브릿지바이오테라퓨틱스",
+    "itmsNm": "브릿지바이오테라퓨틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "365900",
+    "fullNm": "브이씨",
+    "itmsNm": "브이씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "251630",
+    "fullNm": "브이원텍",
+    "itmsNm": "브이원텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "018290",
+    "fullNm": "브이티지엠피",
+    "itmsNm": "브이티지엠피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "044480",
+    "fullNm": "블레이드엔터테인먼트",
+    "itmsNm": "블레이드 Ent",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033560",
+    "fullNm": "블루콤",
+    "itmsNm": "블루콤",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "191600",
+    "fullNm": "블루탑",
+    "itmsNm": "블루탑",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "369370",
+    "fullNm": "블리츠웨이",
+    "itmsNm": "블리츠웨이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "126340",
+    "fullNm": "비나텍",
+    "itmsNm": "비나텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "121800",
+    "fullNm": "비덴트",
+    "itmsNm": "비덴트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "148140",
+    "fullNm": "비디아이",
+    "itmsNm": "비디아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "082800",
+    "fullNm": "비보존제약",
+    "itmsNm": "비보존 제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "318410",
+    "fullNm": "비비씨",
+    "itmsNm": "비비씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002070",
+    "fullNm": "비비안보통주",
+    "itmsNm": "비비안",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "100220",
+    "fullNm": "비상교육 보통주",
+    "itmsNm": "비상교육",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "419540",
+    "fullNm": "비스토스",
+    "itmsNm": "비스토스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "146320",
+    "fullNm": "비씨엔씨",
+    "itmsNm": "비씨엔씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "200780",
+    "fullNm": "비씨월드제약",
+    "itmsNm": "비씨월드제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "141000",
+    "fullNm": "비아트론",
+    "itmsNm": "비아트론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "090460",
+    "fullNm": "비에이치",
+    "itmsNm": "비에이치",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "083650",
+    "fullNm": "비에이치아이",
+    "itmsNm": "비에이치아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "215050",
+    "fullNm": "비엔디생활건강",
+    "itmsNm": "비엔디생활건강",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "032790",
+    "fullNm": "비엔지티",
+    "itmsNm": "비엔지티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "445360",
+    "fullNm": "비엔케이제1호기업인수목적",
+    "itmsNm": "비엔케이제1호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "142760",
+    "fullNm": "비엘",
+    "itmsNm": "비엘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065170",
+    "fullNm": "비엘팜텍",
+    "itmsNm": "비엘팜텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "086220",
+    "fullNm": "비엘헬스케어",
+    "itmsNm": "비엘헬스케어",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "086670",
+    "fullNm": "비엠티",
+    "itmsNm": "비엠티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "335890",
+    "fullNm": "비올",
+    "itmsNm": "비올",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "138580",
+    "fullNm": "비즈니스온커뮤니케이션",
+    "itmsNm": "비즈니스온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "126600",
+    "fullNm": "비지에프에코머티리얼즈",
+    "itmsNm": "BGF에코머티리얼즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "082920",
+    "fullNm": "비츠로셀",
+    "itmsNm": "비츠로셀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054220",
+    "fullNm": "비츠로시스",
+    "itmsNm": "비츠로시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "042370",
+    "fullNm": "비츠로테크",
+    "itmsNm": "비츠로테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "030790",
+    "fullNm": "비케이탑스보통주",
+    "itmsNm": "비케이탑스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "050090",
+    "fullNm": "비케이홀딩스",
+    "itmsNm": "비케이홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "307870",
+    "fullNm": "비투엔",
+    "itmsNm": "비투엔",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "357880",
+    "fullNm": "비트나인",
+    "itmsNm": "비트나인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032850",
+    "fullNm": "비트컴퓨터",
+    "itmsNm": "비트컴퓨터",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "148780",
+    "fullNm": "비플라이소프트",
+    "itmsNm": "비플라이소프트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "238200",
+    "fullNm": "비피도",
+    "itmsNm": "비피도",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "093190",
+    "fullNm": "빅솔론",
+    "itmsNm": "빅솔론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065450",
+    "fullNm": "빅텍",
+    "itmsNm": "빅텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "210120",
+    "fullNm": "빅토리콘텐츠",
+    "itmsNm": "빅텐츠",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "005180",
+    "fullNm": "빙그레보통주",
+    "itmsNm": "빙그레",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "072950",
+    "fullNm": "빛샘전자",
+    "itmsNm": "빛샘전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "266170",
+    "fullNm": "뿌리깊은나무들",
+    "itmsNm": "뿌리깊은나무들",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "143240",
+    "fullNm": "사람인에이치알",
+    "itmsNm": "사람인에이치알",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003960",
+    "fullNm": "사조대림보통주",
+    "itmsNm": "사조대림",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "008040",
+    "fullNm": "사조동아원보통주",
+    "itmsNm": "사조동아원",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007160",
+    "fullNm": "사조산업보통주",
+    "itmsNm": "사조산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "014710",
+    "fullNm": "사조씨푸드보통주",
+    "itmsNm": "사조씨푸드",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006090",
+    "fullNm": "사조오양보통주",
+    "itmsNm": "사조오양",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "419120",
+    "fullNm": "산돌",
+    "itmsNm": "산돌",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "100090",
+    "fullNm": "삼강엠앤티",
+    "itmsNm": "삼강엠앤티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "122350",
+    "fullNm": "삼기",
+    "itmsNm": "삼기",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "014970",
+    "fullNm": "삼륭물산",
+    "itmsNm": "삼륭물산",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "018310",
+    "fullNm": "삼목에스폼",
+    "itmsNm": "삼목에스폼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053700",
+    "fullNm": "삼보모터스",
+    "itmsNm": "삼보모터스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009620",
+    "fullNm": "삼보산업",
+    "itmsNm": "삼보산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "023600",
+    "fullNm": "삼보판지",
+    "itmsNm": "삼보판지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001470",
+    "fullNm": "삼부토건보통주",
+    "itmsNm": "삼부토건",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006405",
+    "fullNm": "삼성SDI1우선주",
+    "itmsNm": "삼성SDI우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006400",
+    "fullNm": "삼성SDI보통주",
+    "itmsNm": "삼성SDI",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006660",
+    "fullNm": "삼성공조보통주",
+    "itmsNm": "삼성공조",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "377630",
+    "fullNm": "삼성기업인수목적4호",
+    "itmsNm": "삼성스팩4호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "425290",
+    "fullNm": "삼성기업인수목적6호",
+    "itmsNm": "삼성스팩6호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "439250",
+    "fullNm": "삼성기업인수목적7호",
+    "itmsNm": "삼성스팩7호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "380320",
+    "fullNm": "삼성머스트기업인수목적5호",
+    "itmsNm": "삼성머스트스팩5호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "02826K",
+    "fullNm": "삼성물산1우선주(신형)",
+    "itmsNm": "삼성물산우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "028260",
+    "fullNm": "삼성물산보통주",
+    "itmsNm": "삼성물산",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "207940",
+    "fullNm": "삼성바이오로직스보통주",
+    "itmsNm": "삼성바이오로직스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "032830",
+    "fullNm": "삼성생명보험보통주",
+    "itmsNm": "삼성생명",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "018260",
+    "fullNm": "삼성에스디에스보통주",
+    "itmsNm": "삼성에스디에스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "028050",
+    "fullNm": "삼성엔지니어링보통주",
+    "itmsNm": "삼성엔지니어링",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009155",
+    "fullNm": "삼성전기1우선주",
+    "itmsNm": "삼성전기우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009150",
+    "fullNm": "삼성전기보통주",
+    "itmsNm": "삼성전기",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005935",
+    "fullNm": "삼성전자1우선주",
+    "itmsNm": "삼성전자우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005930",
+    "fullNm": "삼성전자보통주",
+    "itmsNm": "삼성전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001360",
+    "fullNm": "삼성제약",
+    "itmsNm": "삼성제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "010145",
+    "fullNm": "삼성중공업1우선주",
+    "itmsNm": "삼성중공우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "010140",
+    "fullNm": "삼성중공업보통주",
+    "itmsNm": "삼성중공업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "016360",
+    "fullNm": "삼성증권보통주",
+    "itmsNm": "삼성증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "068290",
+    "fullNm": "삼성출판사보통주",
+    "itmsNm": "삼성출판사",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "029780",
+    "fullNm": "삼성카드 보통주",
+    "itmsNm": "삼성카드",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000815",
+    "fullNm": "삼성화재해상보험1우선주",
+    "itmsNm": "삼성화재우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000810",
+    "fullNm": "삼성화재해상보험보통주",
+    "itmsNm": "삼성화재",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006110",
+    "fullNm": "삼아알미늄보통주",
+    "itmsNm": "삼아알미늄",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009300",
+    "fullNm": "삼아제약",
+    "itmsNm": "삼아제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "145995",
+    "fullNm": "삼양사1우선주",
+    "itmsNm": "삼양사우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "145990",
+    "fullNm": "삼양사보통주",
+    "itmsNm": "삼양사",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003230",
+    "fullNm": "삼양식품보통주",
+    "itmsNm": "삼양식품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "225190",
+    "fullNm": "삼양옵틱스",
+    "itmsNm": "삼양옵틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002170",
+    "fullNm": "삼양통상보통주",
+    "itmsNm": "삼양통상",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "272550",
+    "fullNm": "삼양패키징보통주",
+    "itmsNm": "삼양패키징",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000075",
+    "fullNm": "삼양홀딩스1우선주",
+    "itmsNm": "삼양홀딩스우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000070",
+    "fullNm": "삼양홀딩스보통주",
+    "itmsNm": "삼양홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "060310",
+    "fullNm": "삼에스코리아",
+    "itmsNm": "3S",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002810",
+    "fullNm": "삼영무역보통주",
+    "itmsNm": "삼영무역",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "361670",
+    "fullNm": "삼영에스앤씨",
+    "itmsNm": "삼영에스앤씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054540",
+    "fullNm": "삼영엠텍",
+    "itmsNm": "삼영엠텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065570",
+    "fullNm": "삼영이엔씨",
+    "itmsNm": "삼영이엔씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005680",
+    "fullNm": "삼영전자공업보통주",
+    "itmsNm": "삼영전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003720",
+    "fullNm": "삼영화학공업보통주",
+    "itmsNm": "삼영화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "023000",
+    "fullNm": "삼원강재 보통주",
+    "itmsNm": "삼원강재",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004380",
+    "fullNm": "삼익THK보통주",
+    "itmsNm": "삼익THK",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002450",
+    "fullNm": "삼익악기보통주",
+    "itmsNm": "삼익악기",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "032280",
+    "fullNm": "삼일",
+    "itmsNm": "삼일",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002290",
+    "fullNm": "삼일기업공사",
+    "itmsNm": "삼일기업공사",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004440",
+    "fullNm": "삼일씨엔에스보통주",
+    "itmsNm": "삼일씨엔에스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000520",
+    "fullNm": "삼일제약보통주",
+    "itmsNm": "삼일제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009770",
+    "fullNm": "삼정펄프 보통주",
+    "itmsNm": "삼정펄프",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "037460",
+    "fullNm": "삼지전자",
+    "itmsNm": "삼지전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032750",
+    "fullNm": "삼진",
+    "itmsNm": "삼진",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054090",
+    "fullNm": "삼진엘앤디",
+    "itmsNm": "삼진엘앤디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005500",
+    "fullNm": "삼진제약보통주",
+    "itmsNm": "삼진제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000250",
+    "fullNm": "삼천당제약",
+    "itmsNm": "삼천당제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004690",
+    "fullNm": "삼천리보통주",
+    "itmsNm": "삼천리",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "024950",
+    "fullNm": "삼천리자전거",
+    "itmsNm": "삼천리자전거",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038500",
+    "fullNm": "삼표시멘트",
+    "itmsNm": "삼표시멘트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "017480",
+    "fullNm": "삼현철강",
+    "itmsNm": "삼현철강",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010960",
+    "fullNm": "삼호개발 보통주",
+    "itmsNm": "삼호개발",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "046390",
+    "fullNm": "삼화네트웍스",
+    "itmsNm": "삼화네트웍스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004450",
+    "fullNm": "삼화왕관보통주",
+    "itmsNm": "삼화왕관",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009470",
+    "fullNm": "삼화전기보통주",
+    "itmsNm": "삼화전기",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011230",
+    "fullNm": "삼화전자공업보통주",
+    "itmsNm": "삼화전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001820",
+    "fullNm": "삼화콘덴서공업보통주",
+    "itmsNm": "삼화콘덴서",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000390",
+    "fullNm": "삼화페인트공업보통주",
+    "itmsNm": "삼화페인트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "027580",
+    "fullNm": "상보",
+    "itmsNm": "상보",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038540",
+    "fullNm": "상상인",
+    "itmsNm": "상상인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101000",
+    "fullNm": "상상인인더스트리",
+    "itmsNm": "상상인인더스트리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "415580",
+    "fullNm": "상상인제3호기업인수목적",
+    "itmsNm": "상상인제3호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001290",
+    "fullNm": "상상인증권보통주",
+    "itmsNm": "상상인증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "041650",
+    "fullNm": "상신브레이크보통주",
+    "itmsNm": "상신브레이크",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "091580",
+    "fullNm": "상신이디피",
+    "itmsNm": "상신이디피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "263810",
+    "fullNm": "상신전자",
+    "itmsNm": "상신전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "089980",
+    "fullNm": "상아프론테크",
+    "itmsNm": "상아프론테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "042940",
+    "fullNm": "상지카일룸",
+    "itmsNm": "상지카일룸",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "042600",
+    "fullNm": "새로닉스",
+    "itmsNm": "새로닉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "075180",
+    "fullNm": "새론오토모티브",
+    "itmsNm": "새론오토모티브",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "107600",
+    "fullNm": "새빗켐",
+    "itmsNm": "새빗켐",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "252990",
+    "fullNm": "샘씨엔에스",
+    "itmsNm": "샘씨엔에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007540",
+    "fullNm": "샘표보통주",
+    "itmsNm": "샘표",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "248170",
+    "fullNm": "샘표식품보통주",
+    "itmsNm": "샘표식품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "378800",
+    "fullNm": "샤페론",
+    "itmsNm": "샤페론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "294630",
+    "fullNm": "서남",
+    "itmsNm": "서남",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038070",
+    "fullNm": "서린바이오사이언스",
+    "itmsNm": "서린바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006730",
+    "fullNm": "서부티엔디",
+    "itmsNm": "서부T&D",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "079650",
+    "fullNm": "서산",
+    "itmsNm": "서산",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "100660",
+    "fullNm": "서암기계공업",
+    "itmsNm": "서암기계공업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007860",
+    "fullNm": "서연보통주",
+    "itmsNm": "서연",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "200880",
+    "fullNm": "서연이화보통주",
+    "itmsNm": "서연이화",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "019770",
+    "fullNm": "서연탑메탈",
+    "itmsNm": "서연탑메탈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "017390",
+    "fullNm": "서울도시가스보통주",
+    "itmsNm": "서울가스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "043710",
+    "fullNm": "서울리거",
+    "itmsNm": "서울리거",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092190",
+    "fullNm": "서울바이오시스",
+    "itmsNm": "서울바이오시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "046890",
+    "fullNm": "서울반도체",
+    "itmsNm": "서울반도체",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "004415",
+    "fullNm": "서울식품공업1우선주",
+    "itmsNm": "서울식품우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004410",
+    "fullNm": "서울식품공업보통주",
+    "itmsNm": "서울식품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "063170",
+    "fullNm": "서울옥션",
+    "itmsNm": "서울옥션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "027040",
+    "fullNm": "서울전자통신",
+    "itmsNm": "서울전자통신",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "018680",
+    "fullNm": "서울제약",
+    "itmsNm": "서울제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "021050",
+    "fullNm": "서원보통주",
+    "itmsNm": "서원",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "093920",
+    "fullNm": "서원인텍",
+    "itmsNm": "서원인텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "189860",
+    "fullNm": "서전기전",
+    "itmsNm": "서전기전",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "178320",
+    "fullNm": "서진시스템",
+    "itmsNm": "서진시스템",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "122690",
+    "fullNm": "서진오토모티브",
+    "itmsNm": "서진오토모티브",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "140070",
+    "fullNm": "서플러스글로벌",
+    "itmsNm": "서플러스글로벌",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "011370",
+    "fullNm": "서한",
+    "itmsNm": "서한",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065710",
+    "fullNm": "서호전기",
+    "itmsNm": "서호전기",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "008490",
+    "fullNm": "서흥보통주",
+    "itmsNm": "서흥",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "035890",
+    "fullNm": "서희건설",
+    "itmsNm": "서희건설",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "357550",
+    "fullNm": "석경에이티",
+    "itmsNm": "석경에이티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003100",
+    "fullNm": "선광",
+    "itmsNm": "선광",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007610",
+    "fullNm": "선도전기보통주",
+    "itmsNm": "선도전기",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "067370",
+    "fullNm": "선바이오",
+    "itmsNm": "선바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002820",
+    "fullNm": "선앤엘보통주",
+    "itmsNm": "SUN&L",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "171090",
+    "fullNm": "선익시스템",
+    "itmsNm": "선익시스템",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "136490",
+    "fullNm": "선진보통주",
+    "itmsNm": "선진",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "086710",
+    "fullNm": "선진뷰티사이언스",
+    "itmsNm": "선진뷰티사이언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "014620",
+    "fullNm": "성광벤드",
+    "itmsNm": "성광벤드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "037350",
+    "fullNm": "성도이엔지",
+    "itmsNm": "성도이엔지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "014915",
+    "fullNm": "성문전자1우선주",
+    "itmsNm": "성문전자우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "014910",
+    "fullNm": "성문전자보통주",
+    "itmsNm": "성문전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003080",
+    "fullNm": "성보화학보통주",
+    "itmsNm": "성보화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004985",
+    "fullNm": "성신양회1우선주",
+    "itmsNm": "성신양회우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004980",
+    "fullNm": "성신양회보통주",
+    "itmsNm": "성신양회",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011300",
+    "fullNm": "성안보통주",
+    "itmsNm": "성안",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "081580",
+    "fullNm": "성우전자",
+    "itmsNm": "성우전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "045300",
+    "fullNm": "성우테크론",
+    "itmsNm": "성우테크론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "015750",
+    "fullNm": "성우하이텍",
+    "itmsNm": "성우하이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "365340",
+    "fullNm": "성일하이텍",
+    "itmsNm": "성일하이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000180",
+    "fullNm": "성창기업지주보통주",
+    "itmsNm": "성창기업지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "080470",
+    "fullNm": "성창오토텍",
+    "itmsNm": "성창오토텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "043260",
+    "fullNm": "성호전자",
+    "itmsNm": "성호전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "148150",
+    "fullNm": "세경하이테크",
+    "itmsNm": "세경하이테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002420",
+    "fullNm": "세기상사보통주",
+    "itmsNm": "세기상사",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "053060",
+    "fullNm": "세동",
+    "itmsNm": "세동",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "340440",
+    "fullNm": "세림비앤지",
+    "itmsNm": "세림B&G",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "017510",
+    "fullNm": "세명전기공업",
+    "itmsNm": "세명전기",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004365",
+    "fullNm": "세방1우선주",
+    "itmsNm": "세방우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004360",
+    "fullNm": "세방보통주",
+    "itmsNm": "세방",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004490",
+    "fullNm": "세방전지보통주",
+    "itmsNm": "세방전지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011560",
+    "fullNm": "세보엠이씨",
+    "itmsNm": "세보엠이씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "396300",
+    "fullNm": "세아메카닉스",
+    "itmsNm": "세아메카닉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001430",
+    "fullNm": "세아베스틸지주보통주",
+    "itmsNm": "세아베스틸지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "306200",
+    "fullNm": "세아제강보통주",
+    "itmsNm": "세아제강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003030",
+    "fullNm": "세아제강지주보통주",
+    "itmsNm": "세아제강지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "019440",
+    "fullNm": "세아특수강보통주",
+    "itmsNm": "세아특수강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "058650",
+    "fullNm": "세아홀딩스보통주",
+    "itmsNm": "세아홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "013000",
+    "fullNm": "세우글로벌보통주",
+    "itmsNm": "세우글로벌",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "100700",
+    "fullNm": "세운메디칼",
+    "itmsNm": "세운메디칼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "024830",
+    "fullNm": "세원물산",
+    "itmsNm": "세원물산",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "091090",
+    "fullNm": "세원이앤씨보통주",
+    "itmsNm": "세원이앤씨",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "021820",
+    "fullNm": "세원정공보통주",
+    "itmsNm": "세원정공",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "067830",
+    "fullNm": "세이브존I&C보통주",
+    "itmsNm": "세이브존I&C",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "033530",
+    "fullNm": "세종공업보통주",
+    "itmsNm": "세종공업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "258830",
+    "fullNm": "세종메디칼",
+    "itmsNm": "세종메디칼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036630",
+    "fullNm": "세종텔레콤",
+    "itmsNm": "세종텔레콤",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039310",
+    "fullNm": "세중",
+    "itmsNm": "세중",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "075580",
+    "fullNm": "세진중공업보통주",
+    "itmsNm": "세진중공업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "067770",
+    "fullNm": "세진티에스",
+    "itmsNm": "세진티에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053450",
+    "fullNm": "세코닉스",
+    "itmsNm": "세코닉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "222810",
+    "fullNm": "세토피아",
+    "itmsNm": "세토피아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "027970",
+    "fullNm": "세하보통주",
+    "itmsNm": "세하",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "252500",
+    "fullNm": "세화피앤씨",
+    "itmsNm": "세화피앤씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "347000",
+    "fullNm": "센코",
+    "itmsNm": "센코",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "308170",
+    "fullNm": "센트랄모텍보통주",
+    "itmsNm": "센트랄모텍",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012600",
+    "fullNm": "센트럴인사이트보통주",
+    "itmsNm": "센트럴인사이트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "331920",
+    "fullNm": "셀레믹스",
+    "itmsNm": "셀레믹스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049180",
+    "fullNm": "셀루메드",
+    "itmsNm": "셀루메드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "299660",
+    "fullNm": "셀리드",
+    "itmsNm": "셀리드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "268600",
+    "fullNm": "셀리버리",
+    "itmsNm": "셀리버리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "108860",
+    "fullNm": "셀바스에이아이",
+    "itmsNm": "셀바스AI",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "208370",
+    "fullNm": "셀바스헬스케어",
+    "itmsNm": "셀바스헬스케어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "258250",
+    "fullNm": "셀젠텍",
+    "itmsNm": "셀젠텍",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "068270",
+    "fullNm": "셀트리온보통주",
+    "itmsNm": "셀트리온",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "068760",
+    "fullNm": "셀트리온제약",
+    "itmsNm": "셀트리온제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "091990",
+    "fullNm": "셀트리온헬스케어",
+    "itmsNm": "셀트리온헬스케어",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "068940",
+    "fullNm": "셀피글로벌",
+    "itmsNm": "셀피글로벌",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060230",
+    "fullNm": "소니드",
+    "itmsNm": "소니드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "290690",
+    "fullNm": "소룩스",
+    "itmsNm": "소룩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "950200",
+    "fullNm": "소마젠",
+    "itmsNm": "소마젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032680",
+    "fullNm": "소프트센",
+    "itmsNm": "소프트센",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032685",
+    "fullNm": "소프트센1우선주",
+    "itmsNm": "소프트센우",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "258790",
+    "fullNm": "소프트캠프",
+    "itmsNm": "소프트캠프",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066910",
+    "fullNm": "손오공",
+    "itmsNm": "손오공",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "043100",
+    "fullNm": "솔고바이오메디칼",
+    "itmsNm": "솔고바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "33637K",
+    "fullNm": "솔루스첨단소재1우선주",
+    "itmsNm": "솔루스첨단소재1우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "33637L",
+    "fullNm": "솔루스첨단소재2우선주(신형)",
+    "itmsNm": "솔루스첨단소재2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "336370",
+    "fullNm": "솔루스첨단소재보통주",
+    "itmsNm": "솔루스첨단소재",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "154040",
+    "fullNm": "솔루에타",
+    "itmsNm": "솔루에타",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "248070",
+    "fullNm": "솔루엠보통주",
+    "itmsNm": "솔루엠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "035610",
+    "fullNm": "솔본",
+    "itmsNm": "솔본",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "357780",
+    "fullNm": "솔브레인",
+    "itmsNm": "솔브레인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036830",
+    "fullNm": "솔브레인홀딩스",
+    "itmsNm": "솔브레인홀딩스",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "304100",
+    "fullNm": "솔트룩스",
+    "itmsNm": "솔트룩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "328380",
+    "fullNm": "솔트웨어",
+    "itmsNm": "솔트웨어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004430",
+    "fullNm": "송원산업보통주",
+    "itmsNm": "송원산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "086980",
+    "fullNm": "쇼박스",
+    "itmsNm": "쇼박스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "050960",
+    "fullNm": "수산아이앤티",
+    "itmsNm": "수산아이앤티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "126720",
+    "fullNm": "수산인더스트리보통주",
+    "itmsNm": "수산인더스트리",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "017550",
+    "fullNm": "수산중공업보통주",
+    "itmsNm": "수산중공업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "084180",
+    "fullNm": "수성샐바시온",
+    "itmsNm": "수성샐바시온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "253840",
+    "fullNm": "수젠텍",
+    "itmsNm": "수젠텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "236200",
+    "fullNm": "슈프리마",
+    "itmsNm": "슈프리마",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "317770",
+    "fullNm": "슈프리마아이디",
+    "itmsNm": "슈프리마아이디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "094840",
+    "fullNm": "슈프리마에이치큐",
+    "itmsNm": "슈프리마에이치큐",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "192440",
+    "fullNm": "슈피겐코리아",
+    "itmsNm": "슈피겐코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "136510",
+    "fullNm": "스마트솔루션즈",
+    "itmsNm": "스마트솔루션즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "099440",
+    "fullNm": "스맥",
+    "itmsNm": "스맥",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033790",
+    "fullNm": "스카이문스테크놀로지",
+    "itmsNm": "스카이문스테크놀로지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "276040",
+    "fullNm": "스코넥엔터테인먼트",
+    "itmsNm": "스코넥",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "159910",
+    "fullNm": "스킨앤스킨",
+    "itmsNm": "스킨앤스킨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "115570",
+    "fullNm": "스타플렉스",
+    "itmsNm": "스타플렉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "330730",
+    "fullNm": "스톤브릿지벤처스",
+    "itmsNm": "스톤브릿지벤처스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "204630",
+    "fullNm": "스튜디오 산타클로스 엔터테인먼트",
+    "itmsNm": "스튜디오산타클로스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "253450",
+    "fullNm": "스튜디오드래곤 주식회사",
+    "itmsNm": "스튜디오드래곤",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "026890",
+    "fullNm": "스틱인베스트먼트보통주",
+    "itmsNm": "스틱인베스트먼트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "013810",
+    "fullNm": "스페코",
+    "itmsNm": "스페코",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049830",
+    "fullNm": "승일",
+    "itmsNm": "승일",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "020710",
+    "fullNm": "시공테크",
+    "itmsNm": "시공테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033170",
+    "fullNm": "시그네틱스",
+    "itmsNm": "시그네틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "048870",
+    "fullNm": "시너지이노베이션",
+    "itmsNm": "시너지이노베이션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "025320",
+    "fullNm": "시노펙스",
+    "itmsNm": "시노펙스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "134790",
+    "fullNm": "시디즈보통주",
+    "itmsNm": "시디즈",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "269620",
+    "fullNm": "시스웍",
+    "itmsNm": "시스웍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "131090",
+    "fullNm": "시큐브",
+    "itmsNm": "시큐브",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "232830",
+    "fullNm": "시큐센",
+    "itmsNm": "시큐센",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "139050",
+    "fullNm": "시티랩스",
+    "itmsNm": "시티랩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "016590",
+    "fullNm": "신대양제지보통주",
+    "itmsNm": "신대양제지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "290520",
+    "fullNm": "신도기연",
+    "itmsNm": "신도기연",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "029530",
+    "fullNm": "신도리코보통주",
+    "itmsNm": "신도리코",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004970",
+    "fullNm": "신라교역보통주",
+    "itmsNm": "신라교역",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001000",
+    "fullNm": "신라섬유",
+    "itmsNm": "신라섬유",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "025870",
+    "fullNm": "신라에스지",
+    "itmsNm": "신라에스지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "215600",
+    "fullNm": "신라젠",
+    "itmsNm": "신라젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065350",
+    "fullNm": "신성델타테크",
+    "itmsNm": "신성델타테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "011930",
+    "fullNm": "신성이엔지보통주",
+    "itmsNm": "신성이엔지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005390",
+    "fullNm": "신성통상보통주",
+    "itmsNm": "신성통상",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "034300",
+    "fullNm": "신세계건설",
+    "itmsNm": "신세계건설",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004170",
+    "fullNm": "신세계보통주",
+    "itmsNm": "신세계",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "035510",
+    "fullNm": "신세계아이앤씨 보통주",
+    "itmsNm": "신세계 I&C",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "031430",
+    "fullNm": "신세계인터내셔날보통주",
+    "itmsNm": "신세계인터내셔날",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "031440",
+    "fullNm": "신세계푸드보통주",
+    "itmsNm": "신세계푸드",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006880",
+    "fullNm": "신송홀딩스보통주",
+    "itmsNm": "신송홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "162300",
+    "fullNm": "신스틸",
+    "itmsNm": "신스틸",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002800",
+    "fullNm": "신신제약",
+    "itmsNm": "신신제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005800",
+    "fullNm": "신영와코루보통주",
+    "itmsNm": "신영와코루",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001725",
+    "fullNm": "신영증권1우선주",
+    "itmsNm": "신영증권우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001720",
+    "fullNm": "신영증권보통주",
+    "itmsNm": "신영증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "344050",
+    "fullNm": "신영해피투모로우제6호기업인수목적",
+    "itmsNm": "신영스팩6호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "419270",
+    "fullNm": "신영해피투모로우제7호기업인수목적",
+    "itmsNm": "신영스팩7호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "430220",
+    "fullNm": "신영해피투모로우제8호기업인수목적",
+    "itmsNm": "신영스팩8호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "445970",
+    "fullNm": "신영해피투모로우제9호기업인수목적",
+    "itmsNm": "신영스팩9호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009270",
+    "fullNm": "신원보통주",
+    "itmsNm": "신원",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "017000",
+    "fullNm": "신원종합개발",
+    "itmsNm": "신원종합개발",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002700",
+    "fullNm": "신일전자보통주",
+    "itmsNm": "신일전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012790",
+    "fullNm": "신일제약",
+    "itmsNm": "신일제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "138070",
+    "fullNm": "신진에스엠",
+    "itmsNm": "신진에스엠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "226330",
+    "fullNm": "신테카바이오",
+    "itmsNm": "신테카바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002870",
+    "fullNm": "신풍보통주",
+    "itmsNm": "신풍",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "019175",
+    "fullNm": "신풍제약1우선주",
+    "itmsNm": "신풍제약우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "019170",
+    "fullNm": "신풍제약보통주",
+    "itmsNm": "신풍제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "055550",
+    "fullNm": "신한금융지주회사보통주",
+    "itmsNm": "신한지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "404990",
+    "fullNm": "신한서부티엔디리츠보통주",
+    "itmsNm": "신한서부티엔디리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "293940",
+    "fullNm": "신한알파리츠보통주",
+    "itmsNm": "신한알파리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "418210",
+    "fullNm": "신한제10호기업인수목적",
+    "itmsNm": "신한제10호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "366330",
+    "fullNm": "신한제7호기업인수목적",
+    "itmsNm": "신한제7호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "393360",
+    "fullNm": "신한제8호기업인수목적",
+    "itmsNm": "신한제8호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "405640",
+    "fullNm": "신한제9호기업인수목적",
+    "itmsNm": "신한제9호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "056700",
+    "fullNm": "신화인터텍",
+    "itmsNm": "신화인터텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "187270",
+    "fullNm": "신화콘텍",
+    "itmsNm": "신화콘텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004080",
+    "fullNm": "신흥보통주",
+    "itmsNm": "신흥",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "243840",
+    "fullNm": "신흥에스이씨",
+    "itmsNm": "신흥에스이씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "257720",
+    "fullNm": "실리콘투",
+    "itmsNm": "실리콘투",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "222800",
+    "fullNm": "심텍",
+    "itmsNm": "심텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036710",
+    "fullNm": "심텍홀딩스",
+    "itmsNm": "심텍홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "160980",
+    "fullNm": "싸이맥스",
+    "itmsNm": "싸이맥스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "356890",
+    "fullNm": "싸이버원",
+    "itmsNm": "싸이버원",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "217330",
+    "fullNm": "싸이토젠",
+    "itmsNm": "싸이토젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "102280",
+    "fullNm": "쌍방울",
+    "itmsNm": "쌍방울",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003410",
+    "fullNm": "쌍용C&E보통주",
+    "itmsNm": "쌍용C&E",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003620",
+    "fullNm": "쌍용자동차보통주",
+    "itmsNm": "쌍용차",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "010280",
+    "fullNm": "쌍용정보통신",
+    "itmsNm": "쌍용정보통신",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004770",
+    "fullNm": "써니전자보통주",
+    "itmsNm": "써니전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "217320",
+    "fullNm": "썬테크",
+    "itmsNm": "썬테크",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "208640",
+    "fullNm": "썸에이지",
+    "itmsNm": "썸에이지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "222420",
+    "fullNm": "쎄노텍",
+    "itmsNm": "쎄노텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "037760",
+    "fullNm": "쎄니트",
+    "itmsNm": "쎄니트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "099320",
+    "fullNm": "쎄트렉아이",
+    "itmsNm": "쎄트렉아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "015540",
+    "fullNm": "쎌마테라퓨틱스보통주",
+    "itmsNm": "쎌마테라퓨틱스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "049960",
+    "fullNm": "쎌바이오텍",
+    "itmsNm": "쎌바이오텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "403550",
+    "fullNm": "쏘카보통주",
+    "itmsNm": "쏘카",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "050890",
+    "fullNm": "쏠리드",
+    "itmsNm": "쏠리드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "013720",
+    "fullNm": "씨비아이",
+    "itmsNm": "CBI",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066790",
+    "fullNm": "씨씨에스충북방송",
+    "itmsNm": "씨씨에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "222080",
+    "fullNm": "씨아이에스",
+    "itmsNm": "씨아이에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004920",
+    "fullNm": "씨아이테크보통주",
+    "itmsNm": "씨아이테크",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "236030",
+    "fullNm": "씨알푸드",
+    "itmsNm": "씨알푸드",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "103660",
+    "fullNm": "씨앗",
+    "itmsNm": "씨앗",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "352480",
+    "fullNm": "씨앤씨인터내셔널",
+    "itmsNm": "씨앤씨인터내셔널",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "245450",
+    "fullNm": "씨앤에스링크",
+    "itmsNm": "씨앤에스링크",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "023460",
+    "fullNm": "씨앤에이치",
+    "itmsNm": "CNH",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "264660",
+    "fullNm": "씨앤지하이테크",
+    "itmsNm": "씨앤지하이테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "352700",
+    "fullNm": "씨앤투스",
+    "itmsNm": "씨앤투스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "056730",
+    "fullNm": "씨앤티85",
+    "itmsNm": "CNT85",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065770",
+    "fullNm": "씨에스",
+    "itmsNm": "CS",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "297090",
+    "fullNm": "씨에스베어링",
+    "itmsNm": "씨에스베어링",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "083660",
+    "fullNm": "씨에스에이코스믹",
+    "itmsNm": "CSA 코스믹",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "112610",
+    "fullNm": "씨에스윈드보통주",
+    "itmsNm": "씨에스윈드",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "359090",
+    "fullNm": "씨엔알리서치",
+    "itmsNm": "씨엔알리서치",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "286000",
+    "fullNm": "씨엔티드림",
+    "itmsNm": "씨엔티드림",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "115530",
+    "fullNm": "씨엔플러스",
+    "itmsNm": "씨엔플러스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "115480",
+    "fullNm": "씨유메디칼시스템",
+    "itmsNm": "씨유메디칼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "376290",
+    "fullNm": "씨유테크",
+    "itmsNm": "씨유테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "189330",
+    "fullNm": "씨이랩",
+    "itmsNm": "씨이랩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000120",
+    "fullNm": "씨제이대한통운보통주",
+    "itmsNm": "CJ대한통운",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "311690",
+    "fullNm": "씨제이바이오사이언스",
+    "itmsNm": "CJ 바이오사이언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "079160",
+    "fullNm": "씨제이씨지브이 보통주",
+    "itmsNm": "CJ CGV",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "035760",
+    "fullNm": "씨제이이엔엠",
+    "itmsNm": "CJ ENM",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "097955",
+    "fullNm": "씨제이제일제당 주식회사 1우선주",
+    "itmsNm": "CJ제일제당 우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "097950",
+    "fullNm": "씨제이제일제당 주식회사 보통주",
+    "itmsNm": "CJ제일제당",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "051500",
+    "fullNm": "씨제이프레시웨이",
+    "itmsNm": "CJ프레시웨이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "096530",
+    "fullNm": "씨젠",
+    "itmsNm": "씨젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "900120",
+    "fullNm": "씨케이에이치푸드앤헬스리미티드",
+    "itmsNm": "씨케이에이치",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101240",
+    "fullNm": "씨큐브",
+    "itmsNm": "씨큐브",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060590",
+    "fullNm": "씨티씨바이오",
+    "itmsNm": "씨티씨바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "260930",
+    "fullNm": "씨티케이",
+    "itmsNm": "씨티케이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "013990",
+    "fullNm": "아가방앤컴퍼니",
+    "itmsNm": "아가방컴퍼니",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "123860",
+    "fullNm": "아나패스",
+    "itmsNm": "아나패스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "025980",
+    "fullNm": "아난티",
+    "itmsNm": "아난티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "008700",
+    "fullNm": "아남전자보통주",
+    "itmsNm": "아남전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "058220",
+    "fullNm": "아리온테크놀로지",
+    "itmsNm": "아리온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "125210",
+    "fullNm": "아모그린텍",
+    "itmsNm": "아모그린텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002795",
+    "fullNm": "아모레G1우선주",
+    "itmsNm": "아모레G우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "00279K",
+    "fullNm": "아모레G3우선주(전환)",
+    "itmsNm": "아모레G3우(전환)",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002790",
+    "fullNm": "아모레G보통주",
+    "itmsNm": "아모레G",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "090435",
+    "fullNm": "아모레퍼시픽 1우선주",
+    "itmsNm": "아모레퍼시픽우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "090430",
+    "fullNm": "아모레퍼시픽 보통주",
+    "itmsNm": "아모레퍼시픽",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "052710",
+    "fullNm": "아모텍",
+    "itmsNm": "아모텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "074430",
+    "fullNm": "아미노로직스",
+    "itmsNm": "아미노로직스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092040",
+    "fullNm": "아미코젠",
+    "itmsNm": "아미코젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "083930",
+    "fullNm": "아바코",
+    "itmsNm": "아바코",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "149950",
+    "fullNm": "아바텍",
+    "itmsNm": "아바텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036010",
+    "fullNm": "아비코전자",
+    "itmsNm": "아비코전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002030",
+    "fullNm": "아세아보통주",
+    "itmsNm": "아세아",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "183190",
+    "fullNm": "아세아시멘트보통주",
+    "itmsNm": "아세아시멘트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002310",
+    "fullNm": "아세아제지보통주",
+    "itmsNm": "아세아제지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "050860",
+    "fullNm": "아세아텍",
+    "itmsNm": "아세아텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "012170",
+    "fullNm": "아센디오보통주",
+    "itmsNm": "아센디오",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "136410",
+    "fullNm": "아셈스",
+    "itmsNm": "아셈스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "246720",
+    "fullNm": "아스타",
+    "itmsNm": "아스타",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "067390",
+    "fullNm": "아스트",
+    "itmsNm": "아스트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "159010",
+    "fullNm": "아스플로",
+    "itmsNm": "아스플로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "127710",
+    "fullNm": "아시아경제",
+    "itmsNm": "아시아경제",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "267850",
+    "fullNm": "아시아나IDT보통주",
+    "itmsNm": "아시아나IDT",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "020560",
+    "fullNm": "아시아나항공 보통주",
+    "itmsNm": "아시아나항공",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "227610",
+    "fullNm": "아우딘퓨쳐스",
+    "itmsNm": "아우딘퓨쳐스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "143160",
+    "fullNm": "아이디스",
+    "itmsNm": "아이디스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054800",
+    "fullNm": "아이디스홀딩스",
+    "itmsNm": "아이디스홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "332370",
+    "fullNm": "아이디피",
+    "itmsNm": "아이디피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "122900",
+    "fullNm": "아이마켓코리아보통주",
+    "itmsNm": "아이마켓코리아",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "339950",
+    "fullNm": "아이비김영",
+    "itmsNm": "아이비김영",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "351340",
+    "fullNm": "아이비케이에스제13호기업인수목적",
+    "itmsNm": "IBKS제13호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "388790",
+    "fullNm": "아이비케이에스제16호기업인수목적",
+    "itmsNm": "IBKS제16호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "405350",
+    "fullNm": "아이비케이에스제17호기업인수목적",
+    "itmsNm": "IBKS제17호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "424760",
+    "fullNm": "아이비케이에스제18호기업인수목적",
+    "itmsNm": "IBKS제18호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "426550",
+    "fullNm": "아이비케이에스제19호기업인수목적",
+    "itmsNm": "IBKS제19호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "439730",
+    "fullNm": "아이비케이에스제20호기업인수목적",
+    "itmsNm": "IBKS제20호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "442770",
+    "fullNm": "아이비케이에스제21호기업인수목적",
+    "itmsNm": "IBKS제21호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "099190",
+    "fullNm": "아이센스",
+    "itmsNm": "아이센스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "289010",
+    "fullNm": "아이스크림에듀",
+    "itmsNm": "아이스크림에듀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214430",
+    "fullNm": "아이쓰리시스템",
+    "itmsNm": "아이쓰리시스템",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "040910",
+    "fullNm": "아이씨디",
+    "itmsNm": "아이씨디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "368600",
+    "fullNm": "아이씨에이치",
+    "itmsNm": "아이씨에이치",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "052860",
+    "fullNm": "아이앤씨테크놀로지",
+    "itmsNm": "아이앤씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010780",
+    "fullNm": "아이에스동서보통주",
+    "itmsNm": "아이에스동서",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "095340",
+    "fullNm": "아이에스시",
+    "itmsNm": "ISC",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "069920",
+    "fullNm": "아이에스이커머스",
+    "itmsNm": "아이에스이커머스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038880",
+    "fullNm": "아이에이",
+    "itmsNm": "아이에이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "307180",
+    "fullNm": "아이엘사이언스",
+    "itmsNm": "아이엘사이언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101390",
+    "fullNm": "아이엠",
+    "itmsNm": "아이엠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "052220",
+    "fullNm": "아이엠비씨",
+    "itmsNm": "iMBC",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "447690",
+    "fullNm": "아이오바이오",
+    "itmsNm": "아이오바이오",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "078860",
+    "fullNm": "아이오케이컴퍼니",
+    "itmsNm": "아이오케이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "090150",
+    "fullNm": "아이윈",
+    "itmsNm": "아이윈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "123010",
+    "fullNm": "아이윈플러스",
+    "itmsNm": "아이윈플러스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "031310",
+    "fullNm": "아이즈비전",
+    "itmsNm": "아이즈비전",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "185490",
+    "fullNm": "아이진",
+    "itmsNm": "아이진",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "059100",
+    "fullNm": "아이컴포넌트",
+    "itmsNm": "아이컴포넌트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "149010",
+    "fullNm": "아이케이세미콘",
+    "itmsNm": "아이케이세미콘",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "262840",
+    "fullNm": "아이퀘스트",
+    "itmsNm": "아이퀘스트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "175250",
+    "fullNm": "아이큐어",
+    "itmsNm": "아이큐어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "052460",
+    "fullNm": "아이크래프트",
+    "itmsNm": "아이크래프트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "119830",
+    "fullNm": "아이텍",
+    "itmsNm": "아이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "052770",
+    "fullNm": "아이톡시",
+    "itmsNm": "아이톡시",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "124500",
+    "fullNm": "아이티센",
+    "itmsNm": "아이티센",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "372800",
+    "fullNm": "아이티아이즈",
+    "itmsNm": "아이티아이즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "099520",
+    "fullNm": "아이티엑스에이아이",
+    "itmsNm": "ITX-AI",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "084850",
+    "fullNm": "아이티엠반도체",
+    "itmsNm": "아이티엠반도체",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "114840",
+    "fullNm": "아이패밀리에스씨",
+    "itmsNm": "아이패밀리에스씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "139990",
+    "fullNm": "아주스틸보통주",
+    "itmsNm": "아주스틸",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "027360",
+    "fullNm": "아주아이비투자",
+    "itmsNm": "아주IB투자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032080",
+    "fullNm": "아즈텍더블유비이",
+    "itmsNm": "아즈텍WB",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "013310",
+    "fullNm": "아진산업",
+    "itmsNm": "아진산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "059120",
+    "fullNm": "아진엑스텍",
+    "itmsNm": "아진엑스텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "158430",
+    "fullNm": "아톤",
+    "itmsNm": "아톤",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "149300",
+    "fullNm": "아퓨어스",
+    "itmsNm": "아퓨어스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "067160",
+    "fullNm": "아프리카티비",
+    "itmsNm": "아프리카TV",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "102950",
+    "fullNm": "아하",
+    "itmsNm": "아하",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "001540",
+    "fullNm": "안국약품",
+    "itmsNm": "안국약품",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053800",
+    "fullNm": "안랩",
+    "itmsNm": "안랩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "251280",
+    "fullNm": "안지오랩",
+    "itmsNm": "안지오랩",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "065660",
+    "fullNm": "안트로젠",
+    "itmsNm": "안트로젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "297570",
+    "fullNm": "알로이스",
+    "itmsNm": "알로이스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001780",
+    "fullNm": "알루코 보통주",
+    "itmsNm": "알루코",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "260660",
+    "fullNm": "알리코제약",
+    "itmsNm": "알리코제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "361570",
+    "fullNm": "알비더블유",
+    "itmsNm": "알비더블유",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "131370",
+    "fullNm": "알서포트",
+    "itmsNm": "알서포트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "140670",
+    "fullNm": "알에스오토메이션",
+    "itmsNm": "알에스오토메이션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "327260",
+    "fullNm": "알에프머트리얼즈",
+    "itmsNm": "RF머트리얼즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "096610",
+    "fullNm": "알에프세미",
+    "itmsNm": "알에프세미",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "218410",
+    "fullNm": "알에프에이치아이씨",
+    "itmsNm": "RFHIC",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "061040",
+    "fullNm": "알에프텍",
+    "itmsNm": "알에프텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "148250",
+    "fullNm": "알엔투테크놀로지",
+    "itmsNm": "알엔투테크놀로지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "347860",
+    "fullNm": "알체라",
+    "itmsNm": "알체라",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "196170",
+    "fullNm": "알테오젠",
+    "itmsNm": "알테오젠",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "123750",
+    "fullNm": "알톤스포츠",
+    "itmsNm": "알톤스포츠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "085810",
+    "fullNm": "알티캐스트",
+    "itmsNm": "알티캐스트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "117670",
+    "fullNm": "알파홀딩스",
+    "itmsNm": "알파홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "314140",
+    "fullNm": "알피바이오",
+    "itmsNm": "알피바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "291650",
+    "fullNm": "압타머사이언스",
+    "itmsNm": "압타머사이언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "293780",
+    "fullNm": "압타바이오",
+    "itmsNm": "압타바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "267810",
+    "fullNm": "앙츠",
+    "itmsNm": "앙츠",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "018250",
+    "fullNm": "애경산업보통주",
+    "itmsNm": "애경산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "161000",
+    "fullNm": "애경케미칼보통주",
+    "itmsNm": "애경케미칼",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "390110",
+    "fullNm": "애니메디솔루션",
+    "itmsNm": "애니메디솔루션",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "196300",
+    "fullNm": "애니젠",
+    "itmsNm": "애니젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "310200",
+    "fullNm": "애니플러스",
+    "itmsNm": "애니플러스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "179530",
+    "fullNm": "애드바이오텍",
+    "itmsNm": "애드바이오텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "900100",
+    "fullNm": "애머릿지코퍼레이션",
+    "itmsNm": "애머릿지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "205500",
+    "fullNm": "액션스퀘어",
+    "itmsNm": "액션스퀘어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "052790",
+    "fullNm": "액토즈소프트",
+    "itmsNm": "액토즈소프트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "290740",
+    "fullNm": "액트로",
+    "itmsNm": "액트로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "238090",
+    "fullNm": "앤디포스",
+    "itmsNm": "앤디포스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092600",
+    "fullNm": "앤씨앤",
+    "itmsNm": "앤씨앤",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "129890",
+    "fullNm": "앱코",
+    "itmsNm": "앱코",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "174900",
+    "fullNm": "앱클론 주식회사",
+    "itmsNm": "앱클론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "255440",
+    "fullNm": "야스",
+    "itmsNm": "야스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "030960",
+    "fullNm": "양지사",
+    "itmsNm": "양지사",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "073570",
+    "fullNm": "어반리튬",
+    "itmsNm": "어반리튬",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "102120",
+    "fullNm": "어보브반도체",
+    "itmsNm": "어보브반도체",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "263540",
+    "fullNm": "어스앤에어로스페이스",
+    "itmsNm": "어스앤에어로스페이스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "238120",
+    "fullNm": "얼라인드제네틱스",
+    "itmsNm": "얼라인드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "224810",
+    "fullNm": "엄지하우스",
+    "itmsNm": "엄지하우스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "019990",
+    "fullNm": "에너토크",
+    "itmsNm": "에너토크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "011090",
+    "fullNm": "에넥스보통주",
+    "itmsNm": "에넥스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "270660",
+    "fullNm": "에브리봇 주식회사",
+    "itmsNm": "에브리봇",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038680",
+    "fullNm": "에스넷시스템",
+    "itmsNm": "에스넷",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "137310",
+    "fullNm": "에스디바이오센서보통주",
+    "itmsNm": "에스디바이오센서",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "217480",
+    "fullNm": "에스디생명공학",
+    "itmsNm": "에스디생명공학",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "121890",
+    "fullNm": "에스디시스템",
+    "itmsNm": "에스디시스템",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "099220",
+    "fullNm": "에스디엔",
+    "itmsNm": "SDN",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "097780",
+    "fullNm": "에스맥",
+    "itmsNm": "에스맥",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "289080",
+    "fullNm": "에스브이인베스트먼트",
+    "itmsNm": "SV인베스트먼트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "151910",
+    "fullNm": "에스비더블유생명과학",
+    "itmsNm": "SBW생명과학",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "389500",
+    "fullNm": "에스비비테크",
+    "itmsNm": "에스비비테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "019550",
+    "fullNm": "에스비아이인베스트먼트",
+    "itmsNm": "SBI인베스트먼트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "034120",
+    "fullNm": "에스비에스보통주",
+    "itmsNm": "SBS",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "046140",
+    "fullNm": "에스비에스콘텐츠허브",
+    "itmsNm": "SBS콘텐츠허브",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "042110",
+    "fullNm": "에스씨디",
+    "itmsNm": "에스씨디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036120",
+    "fullNm": "에스씨아이평가정보",
+    "itmsNm": "SCI평가정보",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "298060",
+    "fullNm": "에스씨엠생명과학",
+    "itmsNm": "에스씨엠생명과학",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065420",
+    "fullNm": "에스아이리소스",
+    "itmsNm": "에스아이리소스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "270210",
+    "fullNm": "에스알바이오텍",
+    "itmsNm": "에스알바이오텍",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "103230",
+    "fullNm": "에스앤더블류",
+    "itmsNm": "에스앤더블류",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "260970",
+    "fullNm": "에스앤디",
+    "itmsNm": "에스앤디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101490",
+    "fullNm": "에스앤에스텍",
+    "itmsNm": "에스앤에스텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "095910",
+    "fullNm": "에스에너지",
+    "itmsNm": "에스에너지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "275630",
+    "fullNm": "에스에스알",
+    "itmsNm": "에스에스알",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "419530",
+    "fullNm": "에스에이엠지엔터테인먼트",
+    "itmsNm": "SAMG엔터",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "031330",
+    "fullNm": "에스에이엠티",
+    "itmsNm": "에스에이엠티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060540",
+    "fullNm": "에스에이티",
+    "itmsNm": "에스에이티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "351320",
+    "fullNm": "에스에이티",
+    "itmsNm": "에스에이티이엔지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "056190",
+    "fullNm": "에스에프에이",
+    "itmsNm": "에스에프에이",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "036540",
+    "fullNm": "에스에프에이반도체",
+    "itmsNm": "SFA반도체",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "080000",
+    "fullNm": "에스엔유프리시젼",
+    "itmsNm": "에스엔유",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "091340",
+    "fullNm": "에스엔케이폴리텍",
+    "itmsNm": "S&K폴리텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214310",
+    "fullNm": "에스엘바이오닉스",
+    "itmsNm": "에스엘바이오닉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005850",
+    "fullNm": "에스엘보통주",
+    "itmsNm": "에스엘",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "246250",
+    "fullNm": "에스엘에스바이오",
+    "itmsNm": "에스엘에스바이오",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "258540",
+    "fullNm": "에스엘테라퓨틱스",
+    "itmsNm": "에스엘테라퓨틱스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "063440",
+    "fullNm": "에스엠라이프디자인그룹",
+    "itmsNm": "SM Life Design",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010580",
+    "fullNm": "에스엠벡셀보통주",
+    "itmsNm": "에스엠벡셀",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "299670",
+    "fullNm": "에스엠비나",
+    "itmsNm": "에스엠비나",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "041510",
+    "fullNm": "에스엠엔터테인먼트",
+    "itmsNm": "에스엠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "048550",
+    "fullNm": "에스엠컬처앤콘텐츠",
+    "itmsNm": "SM C&C",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007820",
+    "fullNm": "에스엠코어",
+    "itmsNm": "에스엠코어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "109610",
+    "fullNm": "에스와이",
+    "itmsNm": "에스와이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "012750",
+    "fullNm": "에스원보통주",
+    "itmsNm": "에스원",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "306040",
+    "fullNm": "에스제이그룹",
+    "itmsNm": "에스제이그룹",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "217910",
+    "fullNm": "에스제이켐",
+    "itmsNm": "에스제이켐",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "004060",
+    "fullNm": "에스지세계물산보통주",
+    "itmsNm": "SG세계물산",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "016250",
+    "fullNm": "에스지씨이테크건설",
+    "itmsNm": "SGC이테크건설",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049470",
+    "fullNm": "에스지에이",
+    "itmsNm": "SGA",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "184230",
+    "fullNm": "에스지에이 솔루션즈",
+    "itmsNm": "SGA솔루션즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "040610",
+    "fullNm": "에스지엔지",
+    "itmsNm": "SG&G",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "255220",
+    "fullNm": "에스지이",
+    "itmsNm": "SG",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006125",
+    "fullNm": "에스케이디스커버리1우선주",
+    "itmsNm": "SK디스커버리우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006120",
+    "fullNm": "에스케이디스커버리보통주",
+    "itmsNm": "SK디스커버리",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "068400",
+    "fullNm": "에스케이렌터카보통주",
+    "itmsNm": "SK렌터카",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "302440",
+    "fullNm": "에스케이바이오사이언스보통주",
+    "itmsNm": "SK바이오사이언스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "326030",
+    "fullNm": "에스케이바이오팜보통주",
+    "itmsNm": "SK바이오팜",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "224020",
+    "fullNm": "에스케이씨에스",
+    "itmsNm": "에스케이씨에스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "408920",
+    "fullNm": "에스케이증권에이씨피씨제7호기업인수목적",
+    "itmsNm": "에스케이증권7호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "435870",
+    "fullNm": "에스케이증권제8호기업인수목적",
+    "itmsNm": "에스케이증권제8호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000660",
+    "fullNm": "에스케이하이닉스보통주",
+    "itmsNm": "SK하이닉스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "096630",
+    "fullNm": "에스코넥",
+    "itmsNm": "에스코넥",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "069510",
+    "fullNm": "에스텍",
+    "itmsNm": "에스텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "041910",
+    "fullNm": "에스텍파마",
+    "itmsNm": "에스텍파마",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "234300",
+    "fullNm": "에스트래픽",
+    "itmsNm": "에스트래픽",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039440",
+    "fullNm": "에스티아이",
+    "itmsNm": "에스티아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "098660",
+    "fullNm": "에스티오",
+    "itmsNm": "에스티오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "052020",
+    "fullNm": "에스티큐브",
+    "itmsNm": "에스티큐브",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "237690",
+    "fullNm": "에스티팜",
+    "itmsNm": "에스티팜",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "050760",
+    "fullNm": "에스폴리텍",
+    "itmsNm": "에스폴리텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "288620",
+    "fullNm": "에스퓨얼셀",
+    "itmsNm": "에스퓨얼셀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "317830",
+    "fullNm": "에스피시스템스",
+    "itmsNm": "에스피시스템스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "058610",
+    "fullNm": "에스피지",
+    "itmsNm": "에스피지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "043340",
+    "fullNm": "에쎈테크",
+    "itmsNm": "에쎈테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "023960",
+    "fullNm": "에쓰씨엔지니어링보통주",
+    "itmsNm": "에쓰씨엔지니어링",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "298690",
+    "fullNm": "에어부산보통주",
+    "itmsNm": "에어부산",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "187660",
+    "fullNm": "에이디엠코리아",
+    "itmsNm": "에이디엠코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054630",
+    "fullNm": "에이디칩스",
+    "itmsNm": "에이디칩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "200710",
+    "fullNm": "에이디테크놀로지",
+    "itmsNm": "에이디테크놀로지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "096690",
+    "fullNm": "에이루트",
+    "itmsNm": "에이루트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078520",
+    "fullNm": "에이블씨엔씨보통주",
+    "itmsNm": "에이블씨엔씨",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "298380",
+    "fullNm": "에이비엘바이오",
+    "itmsNm": "에이비엘바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "203400",
+    "fullNm": "에이비온",
+    "itmsNm": "에이비온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "195990",
+    "fullNm": "에이비프로바이오",
+    "itmsNm": "에이비프로바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003800",
+    "fullNm": "에이스침대",
+    "itmsNm": "에이스침대",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "088800",
+    "fullNm": "에이스테크놀로지",
+    "itmsNm": "에이스테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "241840",
+    "fullNm": "에이스토리",
+    "itmsNm": "에이스토리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "311960",
+    "fullNm": "에이아이더뉴트리진",
+    "itmsNm": "에이아이더뉴트리진",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "312610",
+    "fullNm": "에이에프더블류",
+    "itmsNm": "에이에프더블류",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "015260",
+    "fullNm": "에이엔피보통주",
+    "itmsNm": "에이엔피",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "234070",
+    "fullNm": "에이원알폼",
+    "itmsNm": "에이원알폼",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "140910",
+    "fullNm": "에이자기관리부동산투자회사보통주",
+    "itmsNm": "에이리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "039570",
+    "fullNm": "에이치디씨랩스보통주",
+    "itmsNm": "HDC랩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "089470",
+    "fullNm": "에이치디씨현대이피보통주",
+    "itmsNm": "HDC현대EP",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "267250",
+    "fullNm": "에이치디현대보통주",
+    "itmsNm": "HD현대",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "297890",
+    "fullNm": "에이치비솔루션",
+    "itmsNm": "HB솔루션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078150",
+    "fullNm": "에이치비테크놀러지",
+    "itmsNm": "HB테크놀러지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "072990",
+    "fullNm": "에이치시티",
+    "itmsNm": "에이치시티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036640",
+    "fullNm": "에이치알에스",
+    "itmsNm": "HRS",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "227100",
+    "fullNm": "에이치앤비디자인",
+    "itmsNm": "에이치앤비디자인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "082740",
+    "fullNm": "에이치에스디엔진보통주",
+    "itmsNm": "HSD엔진",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "044990",
+    "fullNm": "에이치엔에스하이텍",
+    "itmsNm": "에이치엔에스하이텍",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "028300",
+    "fullNm": "에이치엘비",
+    "itmsNm": "HLB",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003580",
+    "fullNm": "에이치엘비글로벌보통주",
+    "itmsNm": "HLB글로벌",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "343090",
+    "fullNm": "에이치엘비사이언스",
+    "itmsNm": "HLB사이언스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "067630",
+    "fullNm": "에이치엘비생명과학",
+    "itmsNm": "HLB생명과학",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "047920",
+    "fullNm": "에이치엘비제약",
+    "itmsNm": "HLB제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "115450",
+    "fullNm": "에이치엘비테라퓨틱스",
+    "itmsNm": "HLB테라퓨틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "239610",
+    "fullNm": "에이치엘사이언스",
+    "itmsNm": "에이치엘사이언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "353070",
+    "fullNm": "에이치엠씨아이비제4호기업인수목적",
+    "itmsNm": "에이치엠씨제4호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "353060",
+    "fullNm": "에이치엠씨아이비제5호기업인수목적",
+    "itmsNm": "에이치엠씨제5호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "011200",
+    "fullNm": "에이치엠엠보통주",
+    "itmsNm": "HMM",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "148930",
+    "fullNm": "에이치와이티씨",
+    "itmsNm": "에이치와이티씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "044780",
+    "fullNm": "에이치케이",
+    "itmsNm": "에이치케이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "195940",
+    "fullNm": "에이치케이이노엔",
+    "itmsNm": "HK이노엔",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "403870",
+    "fullNm": "에이치피에스피",
+    "itmsNm": "HPSP",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "357230",
+    "fullNm": "에이치피오",
+    "itmsNm": "에이치피오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "071670",
+    "fullNm": "에이테크솔루션",
+    "itmsNm": "에이테크솔루션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "045660",
+    "fullNm": "에이텍",
+    "itmsNm": "에이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "224110",
+    "fullNm": "에이텍티앤",
+    "itmsNm": "에이텍티앤",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "230980",
+    "fullNm": "에이트원",
+    "itmsNm": "에이트원",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "021080",
+    "fullNm": "에이티넘인베스트먼트",
+    "itmsNm": "에이티넘인베스트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "089530",
+    "fullNm": "에이티세미콘",
+    "itmsNm": "에이티세미콘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "200470",
+    "fullNm": "에이팩트",
+    "itmsNm": "에이팩트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "207490",
+    "fullNm": "에이펙스인텍",
+    "itmsNm": "에이펙스인텍",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "262260",
+    "fullNm": "에이프로",
+    "itmsNm": "에이프로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003060",
+    "fullNm": "에이프로젠바이오로직스보통주",
+    "itmsNm": "에이프로젠바이오로직스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007460",
+    "fullNm": "에이프로젠보통주",
+    "itmsNm": "에이프로젠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "109960",
+    "fullNm": "에이프로젠헬스케어앤게임즈",
+    "itmsNm": "에이프로젠 H&G",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "397030",
+    "fullNm": "에이프릴바이오",
+    "itmsNm": "에이프릴바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "244920",
+    "fullNm": "에이플러스에셋보통주",
+    "itmsNm": "에이플러스에셋",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "265520",
+    "fullNm": "에이피시스템",
+    "itmsNm": "AP시스템",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054620",
+    "fullNm": "에이피에스홀딩스",
+    "itmsNm": "APS홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "211270",
+    "fullNm": "에이피위성",
+    "itmsNm": "AP위성",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "089970",
+    "fullNm": "에이피티씨",
+    "itmsNm": "에이피티씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "230240",
+    "fullNm": "에치에프알",
+    "itmsNm": "에치에프알",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "230360",
+    "fullNm": "에코마케팅",
+    "itmsNm": "에코마케팅",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "038870",
+    "fullNm": "에코바이오홀딩스",
+    "itmsNm": "에코바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101360",
+    "fullNm": "에코앤드림",
+    "itmsNm": "에코앤드림",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "128540",
+    "fullNm": "에코캡",
+    "itmsNm": "에코캡",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "086520",
+    "fullNm": "에코프로",
+    "itmsNm": "에코프로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "247540",
+    "fullNm": "에코프로비엠",
+    "itmsNm": "에코프로비엠",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "383310",
+    "fullNm": "에코프로에이치엔",
+    "itmsNm": "에코프로에이치엔",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038110",
+    "fullNm": "에코플라스틱",
+    "itmsNm": "에코플라스틱",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "073540",
+    "fullNm": "에프알텍",
+    "itmsNm": "에프알텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "064850",
+    "fullNm": "에프앤가이드",
+    "itmsNm": "에프앤가이드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "064090",
+    "fullNm": "에프앤리퍼블릭",
+    "itmsNm": "에프앤리퍼블릭",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214270",
+    "fullNm": "에프에스엔",
+    "itmsNm": "FSN",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036810",
+    "fullNm": "에프에스티",
+    "itmsNm": "에프에스티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "173940",
+    "fullNm": "에프엔씨엔터테인먼트",
+    "itmsNm": "에프엔씨엔터",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "083500",
+    "fullNm": "에프엔에스테크",
+    "itmsNm": "에프엔에스테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054940",
+    "fullNm": "엑사이엔씨",
+    "itmsNm": "엑사이엔씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "043090",
+    "fullNm": "엑서지21",
+    "itmsNm": "엑서지21",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "950130",
+    "fullNm": "엑세스바이오",
+    "itmsNm": "엑세스바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "205100",
+    "fullNm": "엑셈",
+    "itmsNm": "엑셈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "070300",
+    "fullNm": "엑스큐어",
+    "itmsNm": "엑스큐어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092870",
+    "fullNm": "엑시콘",
+    "itmsNm": "엑시콘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "317870",
+    "fullNm": "엔바이오니아",
+    "itmsNm": "엔바이오니아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "067570",
+    "fullNm": "엔브이에이치코리아",
+    "itmsNm": "엔브이에이치코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "236810",
+    "fullNm": "엔비티",
+    "itmsNm": "엔비티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "140610",
+    "fullNm": "엔솔바이오사이언스",
+    "itmsNm": "엔솔바이오사이언스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "333620",
+    "fullNm": "엔시스",
+    "itmsNm": "엔시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101400",
+    "fullNm": "엔시트론",
+    "itmsNm": "엔시트론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036570",
+    "fullNm": "엔씨소프트보통주",
+    "itmsNm": "엔씨소프트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "031860",
+    "fullNm": "엔에스엔",
+    "itmsNm": "엔에스엔",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "238170",
+    "fullNm": "엔에스엠",
+    "itmsNm": "엔에스엠",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "224760",
+    "fullNm": "엔에스컴퍼니",
+    "itmsNm": "엔에스컴퍼니",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "380440",
+    "fullNm": "엔에이치기업인수목적19호보통주",
+    "itmsNm": "엔에이치스팩19호",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "391060",
+    "fullNm": "엔에이치기업인수목적20호",
+    "itmsNm": "엔에이치스팩20호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "396770",
+    "fullNm": "엔에이치기업인수목적22호",
+    "itmsNm": "엔에이치스팩22호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "422040",
+    "fullNm": "엔에이치기업인수목적23호",
+    "itmsNm": "엔에이치스팩23호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "437780",
+    "fullNm": "엔에이치기업인수목적24호",
+    "itmsNm": "엔에이치스팩24호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "438580",
+    "fullNm": "엔에이치기업인수목적25호",
+    "itmsNm": "엔에이치스팩25호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "439410",
+    "fullNm": "엔에이치기업인수목적26호",
+    "itmsNm": "엔에이치스팩26호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "440820",
+    "fullNm": "엔에이치기업인수목적27호",
+    "itmsNm": "엔에이치스팩27호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "104200",
+    "fullNm": "엔에이치엔벅스",
+    "itmsNm": "NHN벅스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060250",
+    "fullNm": "엔에이치엔한국사이버결제",
+    "itmsNm": "NHN한국사이버결제",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "400760",
+    "fullNm": "엔에이치올원리츠보통주",
+    "itmsNm": "NH올원리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005945",
+    "fullNm": "엔에이치투자증권1우선주",
+    "itmsNm": "NH투자증권우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005940",
+    "fullNm": "엔에이치투자증권보통주",
+    "itmsNm": "NH투자증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "265740",
+    "fullNm": "엔에프씨",
+    "itmsNm": "엔에프씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053290",
+    "fullNm": "엔이능률",
+    "itmsNm": "NE능률",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "354200",
+    "fullNm": "엔젠바이오",
+    "itmsNm": "엔젠바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "419080",
+    "fullNm": "엔젯",
+    "itmsNm": "엔젯",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "093510",
+    "fullNm": "엔지브이아이",
+    "itmsNm": "엔지브이아이",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "208860",
+    "fullNm": "엔지스테크널러지",
+    "itmsNm": "엔지스테크널러지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "183490",
+    "fullNm": "엔지켐생명과학",
+    "itmsNm": "엔지켐생명과학",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "085310",
+    "fullNm": "엔케이 보통주",
+    "itmsNm": "엔케이",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "182400",
+    "fullNm": "엔케이맥스",
+    "itmsNm": "엔케이맥스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "348370",
+    "fullNm": "엔켐",
+    "itmsNm": "엔켐",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "069410",
+    "fullNm": "엔텔스",
+    "itmsNm": "엔텔스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "227950",
+    "fullNm": "엔투텍",
+    "itmsNm": "엔투텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "291230",
+    "fullNm": "엔피",
+    "itmsNm": "엔피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "198080",
+    "fullNm": "엔피디",
+    "itmsNm": "엔피디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "048830",
+    "fullNm": "엔피케이",
+    "itmsNm": "엔피케이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "096870",
+    "fullNm": "엘디티",
+    "itmsNm": "엘디티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "276240",
+    "fullNm": "엘리비젼",
+    "itmsNm": "엘리비젼",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "900140",
+    "fullNm": "엘브이엠씨홀딩스보통주",
+    "itmsNm": "엘브이엠씨홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "376190",
+    "fullNm": "엘비루셈",
+    "itmsNm": "엘비루셈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "061970",
+    "fullNm": "엘비세미콘",
+    "itmsNm": "엘비세미콘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "138690",
+    "fullNm": "엘아이에스",
+    "itmsNm": "엘아이에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "290650",
+    "fullNm": "엘앤씨바이오",
+    "itmsNm": "엘앤씨바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066970",
+    "fullNm": "엘앤에프",
+    "itmsNm": "엘앤에프",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "156100",
+    "fullNm": "엘앤케이바이오메드",
+    "itmsNm": "엘앤케이바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "229640",
+    "fullNm": "엘에스전선아시아보통주",
+    "itmsNm": "LS전선아시아",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "311060",
+    "fullNm": "엘에이티",
+    "itmsNm": "엘에이티",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "108675",
+    "fullNm": "엘엑스하우시스1우선주",
+    "itmsNm": "LX하우시스우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "108670",
+    "fullNm": "엘엑스하우시스보통주",
+    "itmsNm": "LX하우시스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "38380K",
+    "fullNm": "엘엑스홀딩스1우선주",
+    "itmsNm": "LX홀딩스1우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "383800",
+    "fullNm": "엘엑스홀딩스보통주",
+    "itmsNm": "LX홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "073110",
+    "fullNm": "엘엠에스",
+    "itmsNm": "엘엠에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "083310",
+    "fullNm": "엘오티베큠",
+    "itmsNm": "엘오티베큠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "037560",
+    "fullNm": "엘지헬로비전보통주",
+    "itmsNm": "LG헬로비전",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "037950",
+    "fullNm": "엘컴텍",
+    "itmsNm": "엘컴텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "170920",
+    "fullNm": "엘티씨",
+    "itmsNm": "엘티씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "058630",
+    "fullNm": "엠게임",
+    "itmsNm": "엠게임",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "058970",
+    "fullNm": "엠로",
+    "itmsNm": "엠로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "019590",
+    "fullNm": "엠벤처투자",
+    "itmsNm": "엠벤처투자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "097520",
+    "fullNm": "엠씨넥스보통주",
+    "itmsNm": "엠씨넥스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "179290",
+    "fullNm": "엠아이텍",
+    "itmsNm": "엠아이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009780",
+    "fullNm": "엠에스씨",
+    "itmsNm": "엠에스씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "123040",
+    "fullNm": "엠에스오토텍",
+    "itmsNm": "엠에스오토텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "323230",
+    "fullNm": "엠에프엠코리아",
+    "itmsNm": "엠에프엠코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033160",
+    "fullNm": "엠케이전자",
+    "itmsNm": "엠케이전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "347890",
+    "fullNm": "엠투아이코퍼레이션",
+    "itmsNm": "엠투아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033310",
+    "fullNm": "엠투엔",
+    "itmsNm": "엠투엔",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "259630",
+    "fullNm": "엠플러스",
+    "itmsNm": "엠플러스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065150",
+    "fullNm": "엠피대산",
+    "itmsNm": "엠피대산",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "050540",
+    "fullNm": "엠피씨플러스",
+    "itmsNm": "엠피씨플러스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "115960",
+    "fullNm": "연우",
+    "itmsNm": "연우",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060850",
+    "fullNm": "영림원소프트랩",
+    "itmsNm": "영림원소프트랩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "014440",
+    "fullNm": "영보화학보통주",
+    "itmsNm": "영보화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007530",
+    "fullNm": "영신금속공업",
+    "itmsNm": "영신금속",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "143540",
+    "fullNm": "영우디에스피",
+    "itmsNm": "영우디에스피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "111770",
+    "fullNm": "영원무역보통주",
+    "itmsNm": "영원무역",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009970",
+    "fullNm": "영원무역홀딩스보통주",
+    "itmsNm": "영원무역홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003520",
+    "fullNm": "영진약품보통주",
+    "itmsNm": "영진약품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "112290",
+    "fullNm": "영창케미칼",
+    "itmsNm": "영창케미칼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000670",
+    "fullNm": "영풍보통주",
+    "itmsNm": "영풍",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "036560",
+    "fullNm": "영풍정밀",
+    "itmsNm": "영풍정밀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006740",
+    "fullNm": "영풍제지보통주",
+    "itmsNm": "영풍제지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012280",
+    "fullNm": "영화금속보통주",
+    "itmsNm": "영화금속",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "265560",
+    "fullNm": "영화테크",
+    "itmsNm": "영화테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "012160",
+    "fullNm": "영흥보통주",
+    "itmsNm": "영흥",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "036000",
+    "fullNm": "예림당",
+    "itmsNm": "예림당",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "250930",
+    "fullNm": "예선테크",
+    "itmsNm": "예선테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053280",
+    "fullNm": "예스이십사",
+    "itmsNm": "예스24",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "015360",
+    "fullNm": "예스코홀딩스보통주",
+    "itmsNm": "예스코홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "122640",
+    "fullNm": "예스티",
+    "itmsNm": "예스티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "900300",
+    "fullNm": "오가닉티코스메틱스홀딩스컴퍼니리미티드",
+    "itmsNm": "오가닉티코스메틱",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "045060",
+    "fullNm": "오공",
+    "itmsNm": "오공",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "080520",
+    "fullNm": "오디텍",
+    "itmsNm": "오디텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007310",
+    "fullNm": "오뚜기보통주",
+    "itmsNm": "오뚜기",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "039830",
+    "fullNm": "오로라월드",
+    "itmsNm": "오로라",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "322310",
+    "fullNm": "오로스테크놀로지",
+    "itmsNm": "오로스테크놀로지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "046120",
+    "fullNm": "오르비텍",
+    "itmsNm": "오르비텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "014940",
+    "fullNm": "오리엔탈정공",
+    "itmsNm": "오리엔탈정공",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002630",
+    "fullNm": "오리엔트바이오보통주",
+    "itmsNm": "오리엔트바이오",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "065500",
+    "fullNm": "오리엔트정공",
+    "itmsNm": "오리엔트정공",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "271560",
+    "fullNm": "오리온보통주",
+    "itmsNm": "오리온",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001800",
+    "fullNm": "오리온홀딩스보통주",
+    "itmsNm": "오리온홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "010470",
+    "fullNm": "오리콤",
+    "itmsNm": "오리콤",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "352910",
+    "fullNm": "오비고",
+    "itmsNm": "오비고",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053980",
+    "fullNm": "오상자이엘",
+    "itmsNm": "오상자이엘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "052420",
+    "fullNm": "오성첨단소재",
+    "itmsNm": "오성첨단소재",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "241790",
+    "fullNm": "오션브릿지",
+    "itmsNm": "오션브릿지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039200",
+    "fullNm": "오스코텍",
+    "itmsNm": "오스코텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "031510",
+    "fullNm": "오스템",
+    "itmsNm": "오스템",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "048260",
+    "fullNm": "오스템임플란트",
+    "itmsNm": "오스템임플란트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "368970",
+    "fullNm": "오에스피",
+    "itmsNm": "오에스피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "138080",
+    "fullNm": "오이솔루션",
+    "itmsNm": "오이솔루션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "080580",
+    "fullNm": "오킨스전자",
+    "itmsNm": "오킨스전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "067170",
+    "fullNm": "오텍",
+    "itmsNm": "오텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "353590",
+    "fullNm": "오토앤",
+    "itmsNm": "오토앤",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "173130",
+    "fullNm": "오파스넷",
+    "itmsNm": "오파스넷",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049480",
+    "fullNm": "오픈베이스",
+    "itmsNm": "오픈베이스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "394280",
+    "fullNm": "오픈엣지테크놀로지",
+    "itmsNm": "오픈엣지테크놀로지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "309930",
+    "fullNm": "오하임아이엔티",
+    "itmsNm": "오하임아이엔티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "244460",
+    "fullNm": "올리패스",
+    "itmsNm": "올리패스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "226950",
+    "fullNm": "올릭스",
+    "itmsNm": "올릭스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "057540",
+    "fullNm": "옴니시스템",
+    "itmsNm": "옴니시스템",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "131030",
+    "fullNm": "옵투스제약",
+    "itmsNm": "옵투스제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "082210",
+    "fullNm": "옵트론텍",
+    "itmsNm": "옵트론텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "109080",
+    "fullNm": "옵티시스",
+    "itmsNm": "옵티시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "380540",
+    "fullNm": "옵티코어",
+    "itmsNm": "옵티코어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "153710",
+    "fullNm": "옵티팜",
+    "itmsNm": "옵티팜",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "051390",
+    "fullNm": "와이더블유",
+    "itmsNm": "YW",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "321820",
+    "fullNm": "와이더플래닛",
+    "itmsNm": "와이더플래닛",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "057030",
+    "fullNm": "와이비엠넷",
+    "itmsNm": "YBM넷",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "122990",
+    "fullNm": "와이솔",
+    "itmsNm": "와이솔",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "232140",
+    "fullNm": "와이아이케이",
+    "itmsNm": "와이아이케이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065530",
+    "fullNm": "와이어블",
+    "itmsNm": "와이어블",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "067900",
+    "fullNm": "와이엔텍",
+    "itmsNm": "와이엔텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "155650",
+    "fullNm": "와이엠씨",
+    "itmsNm": "와이엠씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "273640",
+    "fullNm": "와이엠텍",
+    "itmsNm": "와이엠텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "251370",
+    "fullNm": "와이엠티",
+    "itmsNm": "와이엠티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066430",
+    "fullNm": "와이오엠",
+    "itmsNm": "와이오엠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "193250",
+    "fullNm": "와이제이엠게임즈",
+    "itmsNm": "와이제이엠게임즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "273060",
+    "fullNm": "와이즈버즈",
+    "itmsNm": "와이즈버즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "019210",
+    "fullNm": "와이지-원",
+    "itmsNm": "와이지-원",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "122870",
+    "fullNm": "와이지엔터테인먼트",
+    "itmsNm": "와이지엔터테인먼트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "037270",
+    "fullNm": "와이지플러스보통주",
+    "itmsNm": "YG PLUS",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011690",
+    "fullNm": "와이투솔루션보통주",
+    "itmsNm": "와이투솔루션",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "040300",
+    "fullNm": "와이티엔",
+    "itmsNm": "YTN",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "332570",
+    "fullNm": "와이팜",
+    "itmsNm": "와이팜",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "079000",
+    "fullNm": "와토스 코리아",
+    "itmsNm": "와토스코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "316140",
+    "fullNm": "우리금융지주보통주",
+    "itmsNm": "우리금융지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "032820",
+    "fullNm": "우리기술",
+    "itmsNm": "우리기술",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "041190",
+    "fullNm": "우리기술투자",
+    "itmsNm": "우리기술투자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "115440",
+    "fullNm": "우리넷",
+    "itmsNm": "우리넷",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "046970",
+    "fullNm": "우리로",
+    "itmsNm": "우리로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "082850",
+    "fullNm": "우리바이오",
+    "itmsNm": "우리바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "215360",
+    "fullNm": "우리산업",
+    "itmsNm": "우리산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "072470",
+    "fullNm": "우리산업홀딩스",
+    "itmsNm": "우리산업홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "073560",
+    "fullNm": "우리손에프앤지 농업회사법인",
+    "itmsNm": "우리손에프앤지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "037400",
+    "fullNm": "우리엔터프라이즈",
+    "itmsNm": "우리엔터프라이즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "153490",
+    "fullNm": "우리이앤엘",
+    "itmsNm": "우리이앤엘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010050",
+    "fullNm": "우리종합금융보통주",
+    "itmsNm": "우리종금",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "101170",
+    "fullNm": "우림피티에스",
+    "itmsNm": "우림피티에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006980",
+    "fullNm": "우성보통주",
+    "itmsNm": "우성",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "066590",
+    "fullNm": "우수AMS",
+    "itmsNm": "우수AMS",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "017370",
+    "fullNm": "우신시스템보통주",
+    "itmsNm": "우신시스템",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "103840",
+    "fullNm": "우양",
+    "itmsNm": "우양",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "046940",
+    "fullNm": "우원개발",
+    "itmsNm": "우원개발",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "215380",
+    "fullNm": "우정바이오",
+    "itmsNm": "우정바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065680",
+    "fullNm": "우주일렉트로닉스",
+    "itmsNm": "우주일렉트로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "105840",
+    "fullNm": "우진보통주",
+    "itmsNm": "우진",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "018620",
+    "fullNm": "우진비앤지",
+    "itmsNm": "우진비앤지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010400",
+    "fullNm": "우진아이엔에스보통주",
+    "itmsNm": "우진아이엔에스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "049800",
+    "fullNm": "우진플라임 보통주",
+    "itmsNm": "우진플라임",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "016880",
+    "fullNm": "웅진보통주",
+    "itmsNm": "웅진",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "095720",
+    "fullNm": "웅진씽크빅 보통주",
+    "itmsNm": "웅진씽크빅",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005820",
+    "fullNm": "원림보통주",
+    "itmsNm": "원림",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "307280",
+    "fullNm": "원바이오젠",
+    "itmsNm": "원바이오젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053080",
+    "fullNm": "원방테크",
+    "itmsNm": "원방테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032940",
+    "fullNm": "원익",
+    "itmsNm": "원익",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "104830",
+    "fullNm": "원익머트리얼즈",
+    "itmsNm": "원익머트리얼즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "240810",
+    "fullNm": "원익아이피에스",
+    "itmsNm": "원익IPS",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "014190",
+    "fullNm": "원익큐브",
+    "itmsNm": "원익큐브",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "074600",
+    "fullNm": "원익큐엔씨",
+    "itmsNm": "원익QnC",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "217820",
+    "fullNm": "원익피앤이",
+    "itmsNm": "원익피앤이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "030530",
+    "fullNm": "원익홀딩스",
+    "itmsNm": "원익홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "012620",
+    "fullNm": "원일특강",
+    "itmsNm": "원일특강",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "382840",
+    "fullNm": "원준",
+    "itmsNm": "원준",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "336570",
+    "fullNm": "원텍",
+    "itmsNm": "원텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "376980",
+    "fullNm": "원티드랩",
+    "itmsNm": "원티드랩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "122830",
+    "fullNm": "원포유",
+    "itmsNm": "원포유",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "008370",
+    "fullNm": "원풍",
+    "itmsNm": "원풍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "008290",
+    "fullNm": "원풍물산",
+    "itmsNm": "원풍물산",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101160",
+    "fullNm": "월덱스",
+    "itmsNm": "월덱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "336060",
+    "fullNm": "웨이버스",
+    "itmsNm": "웨이버스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "095270",
+    "fullNm": "웨이브일렉트로닉스",
+    "itmsNm": "웨이브일렉트로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010600",
+    "fullNm": "웰바이오텍보통주",
+    "itmsNm": "웰바이오텍",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "065950",
+    "fullNm": "웰크론",
+    "itmsNm": "웰크론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "076080",
+    "fullNm": "웰크론한텍",
+    "itmsNm": "웰크론한텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "196700",
+    "fullNm": "웹스",
+    "itmsNm": "웹스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "069080",
+    "fullNm": "웹젠",
+    "itmsNm": "웹젠",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "053580",
+    "fullNm": "웹케시",
+    "itmsNm": "웹케시",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "071460",
+    "fullNm": "위니아",
+    "itmsNm": "위니아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "377460",
+    "fullNm": "위니아에이드",
+    "itmsNm": "위니아에이드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "044340",
+    "fullNm": "위닉스",
+    "itmsNm": "위닉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "330350",
+    "fullNm": "위더스제약",
+    "itmsNm": "위더스제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "348350",
+    "fullNm": "위드텍",
+    "itmsNm": "위드텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "112040",
+    "fullNm": "위메이드",
+    "itmsNm": "위메이드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101730",
+    "fullNm": "위메이드맥스",
+    "itmsNm": "위메이드맥스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "123420",
+    "fullNm": "위메이드플레이",
+    "itmsNm": "위메이드플레이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065370",
+    "fullNm": "위세아이텍",
+    "itmsNm": "위세아이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "140660",
+    "fullNm": "위월드 주식회사",
+    "itmsNm": "위월드",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "038620",
+    "fullNm": "위즈코프",
+    "itmsNm": "위즈코프",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "299900",
+    "fullNm": "위지윅스튜디오",
+    "itmsNm": "위지윅스튜디오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036090",
+    "fullNm": "위지트",
+    "itmsNm": "위지트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "136540",
+    "fullNm": "윈스",
+    "itmsNm": "윈스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "320000",
+    "fullNm": "윈텍",
+    "itmsNm": "윈텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "097800",
+    "fullNm": "윈팩",
+    "itmsNm": "윈팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "192390",
+    "fullNm": "윈하이텍",
+    "itmsNm": "윈하이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "313760",
+    "fullNm": "윌링스",
+    "itmsNm": "윌링스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "008600",
+    "fullNm": "윌비스보통주",
+    "itmsNm": "윌비스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "335870",
+    "fullNm": "윙스풋",
+    "itmsNm": "윙스풋",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "900340",
+    "fullNm": "윙입푸드홀딩스",
+    "itmsNm": "윙입푸드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "064510",
+    "fullNm": "유네코",
+    "itmsNm": "유네코",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "014830",
+    "fullNm": "유니드 보통주",
+    "itmsNm": "유니드",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "446070",
+    "fullNm": "유니드비티플러스보통주",
+    "itmsNm": "유니드비티플러스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "036200",
+    "fullNm": "유니셈",
+    "itmsNm": "유니셈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "018000",
+    "fullNm": "유니슨",
+    "itmsNm": "유니슨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "047400",
+    "fullNm": "유니온머티리얼보통주",
+    "itmsNm": "유니온머티리얼",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000910",
+    "fullNm": "유니온보통주",
+    "itmsNm": "유니온",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "203450",
+    "fullNm": "유니온커뮤니티",
+    "itmsNm": "유니온커뮤니티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "011330",
+    "fullNm": "유니켐보통주",
+    "itmsNm": "유니켐",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "077500",
+    "fullNm": "유니퀘스트 보통주",
+    "itmsNm": "유니퀘스트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011320",
+    "fullNm": "유니크",
+    "itmsNm": "유니크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "086390",
+    "fullNm": "유니테스트",
+    "itmsNm": "유니테스트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "241690",
+    "fullNm": "유니테크노",
+    "itmsNm": "유니테크노",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "142210",
+    "fullNm": "유니트론텍",
+    "itmsNm": "유니트론텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "121060",
+    "fullNm": "유니포인트",
+    "itmsNm": "유니포인트",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "048430",
+    "fullNm": "유라테크",
+    "itmsNm": "유라테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "206650",
+    "fullNm": "유바이오로직스",
+    "itmsNm": "유바이오로직스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "089850",
+    "fullNm": "유비벨록스",
+    "itmsNm": "유비벨록스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "084440",
+    "fullNm": "유비온",
+    "itmsNm": "유비온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032620",
+    "fullNm": "유비케어",
+    "itmsNm": "유비케어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "264450",
+    "fullNm": "유비쿼스",
+    "itmsNm": "유비쿼스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078070",
+    "fullNm": "유비쿼스홀딩스",
+    "itmsNm": "유비쿼스홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002920",
+    "fullNm": "유성기업보통주",
+    "itmsNm": "유성기업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "024800",
+    "fullNm": "유성티엔에스",
+    "itmsNm": "유성티엔에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000700",
+    "fullNm": "유수홀딩스보통주",
+    "itmsNm": "유수홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "054930",
+    "fullNm": "유신",
+    "itmsNm": "유신",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038340",
+    "fullNm": "유씨아이",
+    "itmsNm": "UCI",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "069330",
+    "fullNm": "유아이디",
+    "itmsNm": "유아이디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049520",
+    "fullNm": "유아이엘",
+    "itmsNm": "유아이엘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "435380",
+    "fullNm": "유안타제10호기업인수목적",
+    "itmsNm": "유안타제10호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "367480",
+    "fullNm": "유안타제8호기업인수목적",
+    "itmsNm": "유안타제8호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "430700",
+    "fullNm": "유안타제9호기업인수목적",
+    "itmsNm": "유안타제9호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003475",
+    "fullNm": "유안타증권1우선주",
+    "itmsNm": "유안타증권우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003470",
+    "fullNm": "유안타증권보통주",
+    "itmsNm": "유안타증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "263770",
+    "fullNm": "유에스티",
+    "itmsNm": "유에스티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "337840",
+    "fullNm": "유엑스엔",
+    "itmsNm": "유엑스엔",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "072130",
+    "fullNm": "유엔젤보통주",
+    "itmsNm": "유엔젤",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000225",
+    "fullNm": "유유제약1우선주",
+    "itmsNm": "유유제약1우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000227",
+    "fullNm": "유유제약2우선주(신형)",
+    "itmsNm": "유유제약2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000220",
+    "fullNm": "유유제약보통주",
+    "itmsNm": "유유제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "388720",
+    "fullNm": "유일로보틱스",
+    "itmsNm": "유일로보틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "340930",
+    "fullNm": "유일에너테크",
+    "itmsNm": "유일에너테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "023410",
+    "fullNm": "유진기업",
+    "itmsNm": "유진기업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "373340",
+    "fullNm": "유진기업인수목적6호",
+    "itmsNm": "유진스팩6호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "388800",
+    "fullNm": "유진기업인수목적7호",
+    "itmsNm": "유진스팩7호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "413630",
+    "fullNm": "유진기업인수목적8호",
+    "itmsNm": "유진스팩8호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "442130",
+    "fullNm": "유진기업인수목적9호",
+    "itmsNm": "유진스팩9호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "056080",
+    "fullNm": "유진로봇",
+    "itmsNm": "유진로봇",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "084370",
+    "fullNm": "유진테크",
+    "itmsNm": "유진테크",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "001200",
+    "fullNm": "유진투자증권보통주",
+    "itmsNm": "유진투자증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "178780",
+    "fullNm": "유테크",
+    "itmsNm": "유테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "221800",
+    "fullNm": "유투바이오",
+    "itmsNm": "유투바이오",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "179900",
+    "fullNm": "유티아이",
+    "itmsNm": "유티아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "263050",
+    "fullNm": "유틸렉스",
+    "itmsNm": "유틸렉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000105",
+    "fullNm": "유한양행1우선주",
+    "itmsNm": "유한양행우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000100",
+    "fullNm": "유한양행보통주",
+    "itmsNm": "유한양행",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003465",
+    "fullNm": "유화증권1우선주",
+    "itmsNm": "유화증권우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003460",
+    "fullNm": "유화증권보통주",
+    "itmsNm": "유화증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "191410",
+    "fullNm": "육일씨엔에쓰",
+    "itmsNm": "육일씨엔에쓰",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "372170",
+    "fullNm": "윤성에프앤씨",
+    "itmsNm": "윤성에프앤씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "008730",
+    "fullNm": "율촌화학보통주",
+    "itmsNm": "율촌화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "072770",
+    "fullNm": "율호",
+    "itmsNm": "율호",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "008250",
+    "fullNm": "이건산업보통주",
+    "itmsNm": "이건산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "039020",
+    "fullNm": "이건홀딩스",
+    "itmsNm": "이건홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "025820",
+    "fullNm": "이구산업보통주",
+    "itmsNm": "이구산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "067920",
+    "fullNm": "이글루코퍼레이션",
+    "itmsNm": "이글루",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "044960",
+    "fullNm": "이글벳",
+    "itmsNm": "이글벳",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "303530",
+    "fullNm": "이노뎁",
+    "itmsNm": "이노뎁",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "296640",
+    "fullNm": "이노룰스",
+    "itmsNm": "이노룰스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "302430",
+    "fullNm": "이노메트리",
+    "itmsNm": "이노메트리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "279060",
+    "fullNm": "이노벡스",
+    "itmsNm": "이노벡스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "214320",
+    "fullNm": "이노션보통주",
+    "itmsNm": "이노션",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "056090",
+    "fullNm": "이노시스",
+    "itmsNm": "이노시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "073490",
+    "fullNm": "이노와이어리스",
+    "itmsNm": "이노와이어리스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "215790",
+    "fullNm": "이노인스트루먼트",
+    "itmsNm": "이노인스트루먼트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "344860",
+    "fullNm": "이노진",
+    "itmsNm": "이노진",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "246960",
+    "fullNm": "이노테라피",
+    "itmsNm": "이노테라피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "088390",
+    "fullNm": "이녹스",
+    "itmsNm": "이녹스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "272290",
+    "fullNm": "이녹스첨단소재",
+    "itmsNm": "이녹스첨단소재",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "053350",
+    "fullNm": "이니텍",
+    "itmsNm": "이니텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "041520",
+    "fullNm": "이라이콤",
+    "itmsNm": "이라이콤",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "264850",
+    "fullNm": "이랜시스",
+    "itmsNm": "이랜시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054210",
+    "fullNm": "이랜텍",
+    "itmsNm": "이랜텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "164060",
+    "fullNm": "이루다",
+    "itmsNm": "이루다",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065440",
+    "fullNm": "이루온",
+    "itmsNm": "이루온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "088260",
+    "fullNm": "이리츠코크렙기업구조조정부동산투자회사보통주",
+    "itmsNm": "이리츠코크렙",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "139480",
+    "fullNm": "이마트보통주",
+    "itmsNm": "이마트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "115610",
+    "fullNm": "이미지스테크놀로지",
+    "itmsNm": "이미지스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078020",
+    "fullNm": "이베스트투자증권",
+    "itmsNm": "이베스트투자증권",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "131400",
+    "fullNm": "이브이첨단소재",
+    "itmsNm": "이브이첨단소재",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "208850",
+    "fullNm": "이비테크",
+    "itmsNm": "이비테크",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "351330",
+    "fullNm": "이삭엔지니어링",
+    "itmsNm": "이삭엔지니어링",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "080010",
+    "fullNm": "이상네트웍스",
+    "itmsNm": "이상네트웍스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "379390",
+    "fullNm": "이성씨엔아이",
+    "itmsNm": "이성씨엔아이",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "086890",
+    "fullNm": "이수앱지스",
+    "itmsNm": "이수앱지스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007660",
+    "fullNm": "이수페타시스보통주",
+    "itmsNm": "이수페타시스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005950",
+    "fullNm": "이수화학보통주",
+    "itmsNm": "이수화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "015020",
+    "fullNm": "이스타코보통주",
+    "itmsNm": "이스타코",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "047560",
+    "fullNm": "이스트소프트",
+    "itmsNm": "이스트소프트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "900110",
+    "fullNm": "이스트아시아홀딩스인베스트먼트리미티드",
+    "itmsNm": "이스트아시아홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "067010",
+    "fullNm": "이씨에스텔레콤",
+    "itmsNm": "이씨에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "093230",
+    "fullNm": "이아이디보통주",
+    "itmsNm": "이아이디",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "341310",
+    "fullNm": "이앤에치",
+    "itmsNm": "이앤에치",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "102710",
+    "fullNm": "이엔에프테크놀로지",
+    "itmsNm": "이엔에프테크놀로지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066980",
+    "fullNm": "이엔코퍼레이션",
+    "itmsNm": "이엔코퍼레이션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "074610",
+    "fullNm": "이엔플러스보통주",
+    "itmsNm": "이엔플러스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "063760",
+    "fullNm": "이엘피",
+    "itmsNm": "이엘피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "123570",
+    "fullNm": "이엠넷",
+    "itmsNm": "이엠넷",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "278990",
+    "fullNm": "이엠비",
+    "itmsNm": "EMB",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "083470",
+    "fullNm": "이엠앤아이",
+    "itmsNm": "이엠앤아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "095190",
+    "fullNm": "이엠코리아",
+    "itmsNm": "이엠코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "091120",
+    "fullNm": "이엠텍",
+    "itmsNm": "이엠텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "232530",
+    "fullNm": "이엠티",
+    "itmsNm": "이엠티",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "102460",
+    "fullNm": "이연제약보통주",
+    "itmsNm": "이연제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "039030",
+    "fullNm": "이오테크닉스",
+    "itmsNm": "이오테크닉스",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "294090",
+    "fullNm": "이오플로우",
+    "itmsNm": "이오플로우",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "245620",
+    "fullNm": "이원다이애그노믹스",
+    "itmsNm": "EDGC",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "088290",
+    "fullNm": "이원컴포텍",
+    "itmsNm": "이원컴포텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "084680",
+    "fullNm": "이월드보통주",
+    "itmsNm": "이월드",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "181340",
+    "fullNm": "이즈미디어",
+    "itmsNm": "이즈미디어",
+    "mrktCtg": "KOSDAQ"
+  },
+  { "srtnCd": "037370", "fullNm": "이지", "itmsNm": "EG", "mrktCtg": "KOSDAQ" },
+  {
+    "srtnCd": "353810",
+    "fullNm": "이지바이오",
+    "itmsNm": "이지바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "350520",
+    "fullNm": "이지스레지던스리츠보통주",
+    "itmsNm": "이지스레지던스리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "334890",
+    "fullNm": "이지스밸류플러스리츠보통주",
+    "itmsNm": "이지스밸류리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "099750",
+    "fullNm": "이지케어텍",
+    "itmsNm": "이지케어텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "377330",
+    "fullNm": "이지트로닉스",
+    "itmsNm": "이지트로닉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "035810",
+    "fullNm": "이지홀딩스",
+    "itmsNm": "이지홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "160600",
+    "fullNm": "이큐셀",
+    "itmsNm": "이큐셀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092130",
+    "fullNm": "이크레더블",
+    "itmsNm": "이크레더블",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "096040",
+    "fullNm": "이트론",
+    "itmsNm": "이트론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "134060",
+    "fullNm": "이퓨쳐",
+    "itmsNm": "이퓨쳐",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001840",
+    "fullNm": "이화공영",
+    "itmsNm": "이화공영",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000760",
+    "fullNm": "이화산업보통주",
+    "itmsNm": "이화산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "024810",
+    "fullNm": "이화전기공업",
+    "itmsNm": "이화전기",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "014990",
+    "fullNm": "인디에프보통주",
+    "itmsNm": "인디에프",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "041830",
+    "fullNm": "인바디",
+    "itmsNm": "인바디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "352940",
+    "fullNm": "인바이오",
+    "itmsNm": "인바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101140",
+    "fullNm": "인바이오젠보통주",
+    "itmsNm": "인바이오젠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "216400",
+    "fullNm": "인바이츠바이오코아",
+    "itmsNm": "인바이츠바이오코아",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "079950",
+    "fullNm": "인베니아",
+    "itmsNm": "인베니아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "389470",
+    "fullNm": "인벤티지랩",
+    "itmsNm": "인벤티지랩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "277410",
+    "fullNm": "인산가",
+    "itmsNm": "인산가",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060150",
+    "fullNm": "인선이엔티",
+    "itmsNm": "인선이엔티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033230",
+    "fullNm": "인성정보",
+    "itmsNm": "인성정보",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006490",
+    "fullNm": "인스코비보통주",
+    "itmsNm": "인스코비",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "037330",
+    "fullNm": "인지디스플레이",
+    "itmsNm": "인지디스플레",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "100030",
+    "fullNm": "인지소프트",
+    "itmsNm": "인지소프트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "023800",
+    "fullNm": "인지컨트롤스보통주",
+    "itmsNm": "인지컨트롤스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "034590",
+    "fullNm": "인천도시가스 보통주",
+    "itmsNm": "인천도시가스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "211050",
+    "fullNm": "인카금융서비스",
+    "itmsNm": "인카금융서비스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "083640",
+    "fullNm": "인콘",
+    "itmsNm": "인콘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "216050",
+    "fullNm": "인크로스",
+    "itmsNm": "인크로스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049070",
+    "fullNm": "인탑스",
+    "itmsNm": "인탑스",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "119610",
+    "fullNm": "인터로조",
+    "itmsNm": "인터로조",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "017250",
+    "fullNm": "인터엠",
+    "itmsNm": "인터엠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "129260",
+    "fullNm": "인터지스보통주",
+    "itmsNm": "인터지스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "051370",
+    "fullNm": "인터플렉스",
+    "itmsNm": "인터플렉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "064290",
+    "fullNm": "인텍플러스",
+    "itmsNm": "인텍플러스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "189300",
+    "fullNm": "인텔리안테크놀로지스",
+    "itmsNm": "인텔리안테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "150840",
+    "fullNm": "인트로메딕",
+    "itmsNm": "인트로메딕",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "048530",
+    "fullNm": "인트론바이오테크놀로지",
+    "itmsNm": "인트론바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "023810",
+    "fullNm": "인팩보통주",
+    "itmsNm": "인팩",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "175140",
+    "fullNm": "인포마크",
+    "itmsNm": "인포마크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "115310",
+    "fullNm": "인포바인",
+    "itmsNm": "인포바인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039290",
+    "fullNm": "인포뱅크",
+    "itmsNm": "인포뱅크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "071200",
+    "fullNm": "인피니트헬스케어",
+    "itmsNm": "인피니트헬스케어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101930",
+    "fullNm": "인화정공",
+    "itmsNm": "인화정공",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "249420",
+    "fullNm": "일동제약보통주",
+    "itmsNm": "일동제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000230",
+    "fullNm": "일동홀딩스보통주",
+    "itmsNm": "일동홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "013360",
+    "fullNm": "일성건설보통주",
+    "itmsNm": "일성건설",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003120",
+    "fullNm": "일성신약보통주",
+    "itmsNm": "일성신약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "333430",
+    "fullNm": "일승",
+    "itmsNm": "일승",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "068330",
+    "fullNm": "일신바이오베이스",
+    "itmsNm": "일신바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003200",
+    "fullNm": "일신방직보통주",
+    "itmsNm": "일신방직",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007110",
+    "fullNm": "일신석재보통주",
+    "itmsNm": "일신석재",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "058450",
+    "fullNm": "일야",
+    "itmsNm": "일야",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007575",
+    "fullNm": "일양약품1우선주",
+    "itmsNm": "일양약품우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007570",
+    "fullNm": "일양약품보통주",
+    "itmsNm": "일양약품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "008500",
+    "fullNm": "일정실업보통주",
+    "itmsNm": "일정실업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "019540",
+    "fullNm": "일지테크",
+    "itmsNm": "일지테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "081000",
+    "fullNm": "일진다이아몬드 보통주",
+    "itmsNm": "일진다이아",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "020760",
+    "fullNm": "일진디스플레이보통주",
+    "itmsNm": "일진디스플",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "020150",
+    "fullNm": "일진머티리얼즈보통주",
+    "itmsNm": "일진머티리얼즈",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "103590",
+    "fullNm": "일진전기 보통주",
+    "itmsNm": "일진전기",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "094820",
+    "fullNm": "일진파워",
+    "itmsNm": "일진파워",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "271940",
+    "fullNm": "일진하이솔루스보통주",
+    "itmsNm": "일진하이솔루스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "015860",
+    "fullNm": "일진홀딩스보통주",
+    "itmsNm": "일진홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "226320",
+    "fullNm": "잇츠한불보통주",
+    "itmsNm": "잇츠한불",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "950140",
+    "fullNm": "잉글우드랩",
+    "itmsNm": "잉글우드랩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049550",
+    "fullNm": "잉크테크",
+    "itmsNm": "잉크테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "254120",
+    "fullNm": "자비스",
+    "itmsNm": "자비스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "043910",
+    "fullNm": "자연과 환경",
+    "itmsNm": "자연과환경",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "234920",
+    "fullNm": "자이글",
+    "itmsNm": "자이글",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "289220",
+    "fullNm": "자이언트스텝",
+    "itmsNm": "자이언트스텝",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "317400",
+    "fullNm": "자이에스앤디보통주",
+    "itmsNm": "자이에스앤디",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "033240",
+    "fullNm": "자화전자보통주",
+    "itmsNm": "자화전자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "174880",
+    "fullNm": "장원테크",
+    "itmsNm": "장원테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049630",
+    "fullNm": "재영솔루텍",
+    "itmsNm": "재영솔루텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "417840",
+    "fullNm": "저스템",
+    "itmsNm": "저스템",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000950",
+    "fullNm": "전방보통주",
+    "itmsNm": "전방",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "110020",
+    "fullNm": "전진바이오팜",
+    "itmsNm": "전진바이오팜",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "208140",
+    "fullNm": "정다운",
+    "itmsNm": "정다운",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "040420",
+    "fullNm": "정상제이엘에스",
+    "itmsNm": "정상제이엘에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "045510",
+    "fullNm": "정원엔시스",
+    "itmsNm": "정원엔시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "217190",
+    "fullNm": "제너셈",
+    "itmsNm": "제너셈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "095700",
+    "fullNm": "제넥신",
+    "itmsNm": "제넥신",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "072520",
+    "fullNm": "제넨바이오",
+    "itmsNm": "제넨바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "122310",
+    "fullNm": "제노레이",
+    "itmsNm": "제노레이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "361390",
+    "fullNm": "제노코",
+    "itmsNm": "제노코",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066830",
+    "fullNm": "제노텍",
+    "itmsNm": "제노텍",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "225220",
+    "fullNm": "제놀루션",
+    "itmsNm": "제놀루션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "123330",
+    "fullNm": "제닉",
+    "itmsNm": "제닉",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "159580",
+    "fullNm": "제로투세븐",
+    "itmsNm": "제로투세븐",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "147830",
+    "fullNm": "제룡산업",
+    "itmsNm": "제룡산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033100",
+    "fullNm": "제룡전기",
+    "itmsNm": "제룡전기",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "079370",
+    "fullNm": "제우스",
+    "itmsNm": "제우스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "067290",
+    "fullNm": "제이더블유신약",
+    "itmsNm": "JW신약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054950",
+    "fullNm": "제이브이엠",
+    "itmsNm": "제이브이엠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "023440",
+    "fullNm": "제이스코홀딩스",
+    "itmsNm": "제이스코홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "090470",
+    "fullNm": "제이스텍",
+    "itmsNm": "제이스텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "287410",
+    "fullNm": "제이시스메디칼",
+    "itmsNm": "제이시스메디칼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "137950",
+    "fullNm": "제이씨케미칼",
+    "itmsNm": "제이씨케미칼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033320",
+    "fullNm": "제이씨현시스템",
+    "itmsNm": "제이씨현시스템",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "417500",
+    "fullNm": "제이아이테크",
+    "itmsNm": "제이아이테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "348950",
+    "fullNm": "제이알글로벌리츠보통주",
+    "itmsNm": "제이알글로벌리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "204270",
+    "fullNm": "제이앤티씨",
+    "itmsNm": "제이앤티씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "194370",
+    "fullNm": "제이에스코퍼레이션보통주",
+    "itmsNm": "제이에스코퍼레이션",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "026040",
+    "fullNm": "제이에스티나",
+    "itmsNm": "제이에스티나",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "126880",
+    "fullNm": "제이엔케이히터",
+    "itmsNm": "제이엔케이히터",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "322510",
+    "fullNm": "제이엘케이",
+    "itmsNm": "제이엘케이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "254160",
+    "fullNm": "제이엠멀티",
+    "itmsNm": "제이엠멀티",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "033050",
+    "fullNm": "제이엠아이",
+    "itmsNm": "제이엠아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "094970",
+    "fullNm": "제이엠티",
+    "itmsNm": "제이엠티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "035900",
+    "fullNm": "제이와이피엔터테인먼트",
+    "itmsNm": "JYP Ent.",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "058420",
+    "fullNm": "제이웨이",
+    "itmsNm": "제이웨이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "025620",
+    "fullNm": "제이준코스메틱보통주",
+    "itmsNm": "제이준코스메틱",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "089790",
+    "fullNm": "제이티",
+    "itmsNm": "제이티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "950170",
+    "fullNm": "제이티씨",
+    "itmsNm": "JTC",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "030000",
+    "fullNm": "제일기획보통주",
+    "itmsNm": "제일기획",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "052670",
+    "fullNm": "제일바이오",
+    "itmsNm": "제일바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "271980",
+    "fullNm": "제일약품보통주",
+    "itmsNm": "제일약품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001560",
+    "fullNm": "제일연마공업보통주",
+    "itmsNm": "제일연마",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "199820",
+    "fullNm": "제일전기공업",
+    "itmsNm": "제일전기공업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038010",
+    "fullNm": "제일테크노스",
+    "itmsNm": "제일테크노스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002620",
+    "fullNm": "제일파마홀딩스보통주",
+    "itmsNm": "제일파마홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "276730",
+    "fullNm": "제주맥주",
+    "itmsNm": "제주맥주",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "080220",
+    "fullNm": "제주반도체",
+    "itmsNm": "제주반도체",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006220",
+    "fullNm": "제주은행보통주",
+    "itmsNm": "제주은행",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "089590",
+    "fullNm": "제주항공보통주",
+    "itmsNm": "제주항공",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "216080",
+    "fullNm": "제테마",
+    "itmsNm": "제테마",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "229000",
+    "fullNm": "젠큐릭스",
+    "itmsNm": "젠큐릭스",
+    "mrktCtg": "KOSDAQ"
+  },
+  { "srtnCd": "248020", "fullNm": "젬", "itmsNm": "젬", "mrktCtg": "KONEX" },
+  {
+    "srtnCd": "082270",
+    "fullNm": "젬백스&카엘",
+    "itmsNm": "젬백스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "064800",
+    "fullNm": "젬백스링크",
+    "itmsNm": "젬백스링크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "044060",
+    "fullNm": "조광아이엘아이",
+    "itmsNm": "조광ILI",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004910",
+    "fullNm": "조광페인트보통주",
+    "itmsNm": "조광페인트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004700",
+    "fullNm": "조광피혁보통주",
+    "itmsNm": "조광피혁",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001550",
+    "fullNm": "조비보통주",
+    "itmsNm": "조비",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000480",
+    "fullNm": "조선내화보통주",
+    "itmsNm": "조선내화",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "120030",
+    "fullNm": "조선선재 보통주",
+    "itmsNm": "조선선재",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "034940",
+    "fullNm": "조아제약",
+    "itmsNm": "조아제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "067000",
+    "fullNm": "조이시티",
+    "itmsNm": "조이시티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "018470",
+    "fullNm": "조일알미늄보통주",
+    "itmsNm": "조일알미늄",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002600",
+    "fullNm": "조흥보통주",
+    "itmsNm": "조흥",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "063160",
+    "fullNm": "종근당바이오보통주",
+    "itmsNm": "종근당바이오",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "185750",
+    "fullNm": "종근당보통주",
+    "itmsNm": "종근당",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001630",
+    "fullNm": "종근당홀딩스보통주",
+    "itmsNm": "종근당홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "033340",
+    "fullNm": "좋은사람들",
+    "itmsNm": "좋은사람들",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036930",
+    "fullNm": "주성엔지니어링",
+    "itmsNm": "주성엔지니어링",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "185190",
+    "fullNm": "주식회사 수프로",
+    "itmsNm": "수프로",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "357580",
+    "fullNm": "주식회사 아모센스",
+    "itmsNm": "아모센스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "226400",
+    "fullNm": "주식회사 오스테오닉",
+    "itmsNm": "오스테오닉",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "070960",
+    "fullNm": "주식회사 용평리조트",
+    "itmsNm": "용평리조트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "187420",
+    "fullNm": "주식회사 제노포커스",
+    "itmsNm": "제노포커스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "189350",
+    "fullNm": "주식회사 코셋",
+    "itmsNm": "코셋",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "023450",
+    "fullNm": "주식회사동남합성",
+    "itmsNm": "동남합성",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002380",
+    "fullNm": "주식회사케이씨씨",
+    "itmsNm": "KCC",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "044380",
+    "fullNm": "주연테크 보통주",
+    "itmsNm": "주연테크",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "239340",
+    "fullNm": "줌인터넷",
+    "itmsNm": "줌인터넷",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "024110",
+    "fullNm": "중소기업은행보통주",
+    "itmsNm": "기업은행",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "051980",
+    "fullNm": "중앙디앤엠",
+    "itmsNm": "중앙디앤엠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "072020",
+    "fullNm": "중앙백신연구소",
+    "itmsNm": "중앙백신",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000440",
+    "fullNm": "중앙에너비스",
+    "itmsNm": "중앙에너비스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078650",
+    "fullNm": "지나인제약",
+    "itmsNm": "지나인제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "228760",
+    "fullNm": "지노믹트리",
+    "itmsNm": "지노믹트리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "314130",
+    "fullNm": "지놈앤컴퍼니",
+    "itmsNm": "지놈앤컴퍼니",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "013890",
+    "fullNm": "지누스보통주",
+    "itmsNm": "지누스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "389030",
+    "fullNm": "지니너스",
+    "itmsNm": "지니너스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "043610",
+    "fullNm": "지니뮤직",
+    "itmsNm": "지니뮤직",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "263860",
+    "fullNm": "지니언스",
+    "itmsNm": "지니언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "303030",
+    "fullNm": "지니틱스",
+    "itmsNm": "지니틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036180",
+    "fullNm": "지더블유바이텍",
+    "itmsNm": "지더블유바이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "208350",
+    "fullNm": "지란지교시큐리티",
+    "itmsNm": "지란지교시큐리티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "144510",
+    "fullNm": "지씨셀",
+    "itmsNm": "지씨셀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "382480",
+    "fullNm": "지아이텍",
+    "itmsNm": "지아이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "382800",
+    "fullNm": "지앤비에스엔지니어링",
+    "itmsNm": "지앤비에스엔지니어링",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "299480",
+    "fullNm": "지앤이헬스케어",
+    "itmsNm": "지앤이헬스케어",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "051160",
+    "fullNm": "지어소프트",
+    "itmsNm": "지어소프트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001250",
+    "fullNm": "지에스글로벌보통주",
+    "itmsNm": "GS글로벌",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007070",
+    "fullNm": "지에스리테일보통주",
+    "itmsNm": "GS리테일",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "053050",
+    "fullNm": "지에스이",
+    "itmsNm": "지에스이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "130500",
+    "fullNm": "지에이치신소재",
+    "itmsNm": "GH신소재",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "388610",
+    "fullNm": "지에프씨생명과학",
+    "itmsNm": "지에프씨생명과학",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "119850",
+    "fullNm": "지엔씨에너지",
+    "itmsNm": "지엔씨에너지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "270520",
+    "fullNm": "지엔원에너지",
+    "itmsNm": "지엔원에너지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065060",
+    "fullNm": "지엔코",
+    "itmsNm": "지엔코",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "204840",
+    "fullNm": "지엘팜텍",
+    "itmsNm": "지엘팜텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "013870",
+    "fullNm": "지엠비코리아보통주",
+    "itmsNm": "지엠비코리아",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "071320",
+    "fullNm": "지역난방공사보통주",
+    "itmsNm": "지역난방공사",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "311320",
+    "fullNm": "지오엘리먼트",
+    "itmsNm": "지오엘리먼트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "035000",
+    "fullNm": "지투알보통주",
+    "itmsNm": "지투알",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "388050",
+    "fullNm": "지투파워",
+    "itmsNm": "지투파워",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "219750",
+    "fullNm": "지티지웰니스",
+    "itmsNm": "지티지웰니스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "088790",
+    "fullNm": "진도 보통주",
+    "itmsNm": "진도",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "018120",
+    "fullNm": "진로발효",
+    "itmsNm": "진로발효",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "109820",
+    "fullNm": "진매트릭스",
+    "itmsNm": "진매트릭스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "086060",
+    "fullNm": "진바이오텍",
+    "itmsNm": "진바이오텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036890",
+    "fullNm": "진성티이씨",
+    "itmsNm": "진성티이씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "363250",
+    "fullNm": "진시스템",
+    "itmsNm": "진시스템",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003780",
+    "fullNm": "진양산업보통주",
+    "itmsNm": "진양산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007370",
+    "fullNm": "진양제약",
+    "itmsNm": "진양제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010640",
+    "fullNm": "진양폴리우레탄보통주",
+    "itmsNm": "진양폴리",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "100250",
+    "fullNm": "진양홀딩스보통주",
+    "itmsNm": "진양홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "051630",
+    "fullNm": "진양화학보통주",
+    "itmsNm": "진양화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "272450",
+    "fullNm": "진에어보통주",
+    "itmsNm": "진에어",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011000",
+    "fullNm": "진원생명과학보통주",
+    "itmsNm": "진원생명과학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "250030",
+    "fullNm": "진코스텍",
+    "itmsNm": "진코스텍",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "002785",
+    "fullNm": "진흥기업1우선주(신형)",
+    "itmsNm": "진흥기업우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002787",
+    "fullNm": "진흥기업2우선주(신형)",
+    "itmsNm": "진흥기업2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002780",
+    "fullNm": "진흥기업보통주",
+    "itmsNm": "진흥기업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "233990",
+    "fullNm": "질경이",
+    "itmsNm": "질경이",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "085660",
+    "fullNm": "차바이오텍",
+    "itmsNm": "차바이오텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "261780",
+    "fullNm": "차백신연구소",
+    "itmsNm": "차백신연구소",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "900250",
+    "fullNm": "차이나크리스탈신소재홀딩스",
+    "itmsNm": "크리스탈신소재",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009310",
+    "fullNm": "참엔지니어링보통주",
+    "itmsNm": "참엔지니어링",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "094850",
+    "fullNm": "참좋은여행",
+    "itmsNm": "참좋은여행",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004650",
+    "fullNm": "창해에탄올",
+    "itmsNm": "창해에탄올",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "278280",
+    "fullNm": "천보",
+    "itmsNm": "천보",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "000650",
+    "fullNm": "천일고속보통주",
+    "itmsNm": "천일고속",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "140290",
+    "fullNm": "청광건설 주식회사",
+    "itmsNm": "청광건설",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "362320",
+    "fullNm": "청담글로벌",
+    "itmsNm": "청담글로벌",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066360",
+    "fullNm": "체리부로",
+    "itmsNm": "체리부로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033250",
+    "fullNm": "체시스보통주",
+    "itmsNm": "체시스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "047820",
+    "fullNm": "초록뱀미디어",
+    "itmsNm": "초록뱀미디어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "131100",
+    "fullNm": "초록뱀이앤엠",
+    "itmsNm": "초록뱀이앤엠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "052300",
+    "fullNm": "초록뱀컴퍼니",
+    "itmsNm": "초록뱀컴퍼니",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "118000",
+    "fullNm": "초록뱀헬스케어보통주",
+    "itmsNm": "초록뱀헬스케어",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "094360",
+    "fullNm": "칩스앤미디어",
+    "itmsNm": "칩스앤미디어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "016790",
+    "fullNm": "카나리아바이오",
+    "itmsNm": "카나리아바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "016920",
+    "fullNm": "카스",
+    "itmsNm": "카스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "284620",
+    "fullNm": "카이노스메드",
+    "itmsNm": "카이노스메드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "446600",
+    "fullNm": "카이바이오텍",
+    "itmsNm": "카이바이오텍",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "293490",
+    "fullNm": "카카오게임즈",
+    "itmsNm": "카카오게임즈",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "323410",
+    "fullNm": "카카오뱅크보통주",
+    "itmsNm": "카카오뱅크",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "035720",
+    "fullNm": "카카오보통주",
+    "itmsNm": "카카오",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "377300",
+    "fullNm": "카카오페이보통주",
+    "itmsNm": "카카오페이",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "042000",
+    "fullNm": "카페24",
+    "itmsNm": "카페24",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006380",
+    "fullNm": "카프로보통주",
+    "itmsNm": "카프로",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "317530",
+    "fullNm": "캐리소프트",
+    "itmsNm": "캐리소프트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "071850",
+    "fullNm": "캐스텍코리아",
+    "itmsNm": "캐스텍코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "050110",
+    "fullNm": "캠시스",
+    "itmsNm": "캠시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "119860",
+    "fullNm": "커넥트웨이브",
+    "itmsNm": "커넥트웨이브",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "223310",
+    "fullNm": "커머스마이너",
+    "itmsNm": "커머스마이너",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "109070",
+    "fullNm": "컨버즈보통주",
+    "itmsNm": "컨버즈",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "900310",
+    "fullNm": "컬러레이홀딩스",
+    "itmsNm": "컬러레이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078340",
+    "fullNm": "컴투스",
+    "itmsNm": "컴투스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "063080",
+    "fullNm": "컴투스홀딩스",
+    "itmsNm": "컴투스홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "307930",
+    "fullNm": "컴퍼니케이파트너스",
+    "itmsNm": "컴퍼니케이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "079190",
+    "fullNm": "케스피온",
+    "itmsNm": "케스피온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "263700",
+    "fullNm": "케어랩스",
+    "itmsNm": "케어랩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214370",
+    "fullNm": "케어젠",
+    "itmsNm": "케어젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "221980",
+    "fullNm": "케이디켐",
+    "itmsNm": "케이디켐",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "900280",
+    "fullNm": "케이만금세기차륜집단유한공사",
+    "itmsNm": "골든센츄리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001620",
+    "fullNm": "케이비아이동국실업보통주",
+    "itmsNm": "케이비아이동국실업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "024840",
+    "fullNm": "케이비아이메탈",
+    "itmsNm": "KBI메탈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "424140",
+    "fullNm": "케이비제21호기업인수목적",
+    "itmsNm": "케이비제21호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "436530",
+    "fullNm": "케이비제22호기업인수목적",
+    "itmsNm": "케이비제22호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "440200",
+    "fullNm": "케이비제23호기업인수목적",
+    "itmsNm": "케이비제23호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "318000",
+    "fullNm": "케이비지",
+    "itmsNm": "KBG",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "192250",
+    "fullNm": "케이사인",
+    "itmsNm": "케이사인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009440",
+    "fullNm": "케이씨그린홀딩스보통주",
+    "itmsNm": "KC그린홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "029460",
+    "fullNm": "케이씨보통주",
+    "itmsNm": "케이씨",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "112190",
+    "fullNm": "케이씨산업",
+    "itmsNm": "KC산업",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "021320",
+    "fullNm": "케이씨씨건설",
+    "itmsNm": "KCC건설",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "344820",
+    "fullNm": "케이씨씨글라스보통주",
+    "itmsNm": "KCC글라스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "036670",
+    "fullNm": "케이씨아이",
+    "itmsNm": "KCI",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "115500",
+    "fullNm": "케이씨에스",
+    "itmsNm": "케이씨에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "119650",
+    "fullNm": "케이씨코트렐보통주",
+    "itmsNm": "KC코트렐",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "281820",
+    "fullNm": "케이씨텍보통주",
+    "itmsNm": "케이씨텍",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "089150",
+    "fullNm": "케이씨티",
+    "itmsNm": "케이씨티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "025880",
+    "fullNm": "케이씨피드",
+    "itmsNm": "케이씨피드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "093320",
+    "fullNm": "케이아이엔엑스",
+    "itmsNm": "케이아이엔엑스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "044450",
+    "fullNm": "케이에스에스 해운 보통주",
+    "itmsNm": "KSS해운",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "073010",
+    "fullNm": "케이에스피",
+    "itmsNm": "케이에스피",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "226360",
+    "fullNm": "케이에이치건설",
+    "itmsNm": "KH 건설",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "060720",
+    "fullNm": "케이에이치바텍",
+    "itmsNm": "KH바텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "111870",
+    "fullNm": "케이에이치전자",
+    "itmsNm": "KH 전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "122450",
+    "fullNm": "케이엑스이노베이션",
+    "itmsNm": "KX",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "052900",
+    "fullNm": "케이엑스하이텍",
+    "itmsNm": "KX하이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "105330",
+    "fullNm": "케이엔더블유",
+    "itmsNm": "케이엔더블유",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "058400",
+    "fullNm": "케이엔엔",
+    "itmsNm": "KNN",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "272110",
+    "fullNm": "케이엔제이",
+    "itmsNm": "케이엔제이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039420",
+    "fullNm": "케이엘넷",
+    "itmsNm": "케이엘넷",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "083550",
+    "fullNm": "케이엠",
+    "itmsNm": "케이엠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032500",
+    "fullNm": "케이엠더블유",
+    "itmsNm": "케이엠더블유",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "225430",
+    "fullNm": "케이엠제약",
+    "itmsNm": "케이엠제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "102370",
+    "fullNm": "케이옥션",
+    "itmsNm": "케이옥션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092220",
+    "fullNm": "케이이씨 보통주",
+    "itmsNm": "KEC",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "046440",
+    "fullNm": "케이지모빌리언스",
+    "itmsNm": "KG모빌리언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "035600",
+    "fullNm": "케이지이니시스",
+    "itmsNm": "KG이니시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "151860",
+    "fullNm": "케이지이티에스",
+    "itmsNm": "KG ETS",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "381970",
+    "fullNm": "케이카보통주",
+    "itmsNm": "케이카",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "145270",
+    "fullNm": "케이탑리츠보통주",
+    "itmsNm": "케이탑리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "030200",
+    "fullNm": "케이티보통주",
+    "itmsNm": "KT",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "060370",
+    "fullNm": "케이티서브마린",
+    "itmsNm": "KT서브마린",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053210",
+    "fullNm": "케이티스카이라이프",
+    "itmsNm": "스카이라이프",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "058850",
+    "fullNm": "케이티씨에스보통주",
+    "itmsNm": "KTcs",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "058860",
+    "fullNm": "케이티아이에스보통주",
+    "itmsNm": "KTis",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "036030",
+    "fullNm": "케이티알파",
+    "itmsNm": "케이티알파",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033780",
+    "fullNm": "케이티앤지보통주",
+    "itmsNm": "KT&G",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "064820",
+    "fullNm": "케이프",
+    "itmsNm": "케이프",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "256940",
+    "fullNm": "케이피에스",
+    "itmsNm": "케이피에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "024880",
+    "fullNm": "케이피에프",
+    "itmsNm": "케이피에프",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "114450",
+    "fullNm": "케이피엑스라이프사이언스",
+    "itmsNm": "KPX생명과학",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "042040",
+    "fullNm": "케이피엠테크",
+    "itmsNm": "케이피엠테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054410",
+    "fullNm": "케이피티유",
+    "itmsNm": "케이피티유",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "258610",
+    "fullNm": "케일럼",
+    "itmsNm": "케일럼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "274090",
+    "fullNm": "켄코아에어로스페이스",
+    "itmsNm": "켄코아에어로스페이스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "402420",
+    "fullNm": "켈스",
+    "itmsNm": "켈스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "089010",
+    "fullNm": "켐트로닉스",
+    "itmsNm": "켐트로닉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "220260",
+    "fullNm": "켐트로스",
+    "itmsNm": "켐트로스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "176590",
+    "fullNm": "코나솔",
+    "itmsNm": "코나솔",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "052400",
+    "fullNm": "코나아이",
+    "itmsNm": "코나아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "402030",
+    "fullNm": "코난테크놀로지",
+    "itmsNm": "코난테크놀로지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "391710",
+    "fullNm": "코닉오토메이션",
+    "itmsNm": "코닉오토메이션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "046070",
+    "fullNm": "코다코",
+    "itmsNm": "코다코",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "047770",
+    "fullNm": "코데즈컴바인",
+    "itmsNm": "코데즈컴바인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078940",
+    "fullNm": "코드네이처",
+    "itmsNm": "코드네이처",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "080530",
+    "fullNm": "코디",
+    "itmsNm": "코디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "417310",
+    "fullNm": "코람코더원리츠보통주",
+    "itmsNm": "코람코더원리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "357120",
+    "fullNm": "코람코에너지플러스리츠보통주",
+    "itmsNm": "코람코에너지리츠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "104540",
+    "fullNm": "코렌텍",
+    "itmsNm": "코렌텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "027050",
+    "fullNm": "코리아나화장품",
+    "itmsNm": "코리아나",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007815",
+    "fullNm": "코리아써키트1우선주",
+    "itmsNm": "코리아써우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "00781K",
+    "fullNm": "코리아써키트2우선주(신형)",
+    "itmsNm": "코리아써키트2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007810",
+    "fullNm": "코리아써키트보통주",
+    "itmsNm": "코리아써키트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "190650",
+    "fullNm": "코리아에셋투자증권",
+    "itmsNm": "코리아에셋투자증권",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "123410",
+    "fullNm": "코리아에프티",
+    "itmsNm": "코리아에프티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003690",
+    "fullNm": "코리안리재보험보통주",
+    "itmsNm": "코리안리",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "036690",
+    "fullNm": "코맥스",
+    "itmsNm": "코맥스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049430",
+    "fullNm": "코메론",
+    "itmsNm": "코메론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "183300",
+    "fullNm": "코미코",
+    "itmsNm": "코미코",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "041960",
+    "fullNm": "코미팜",
+    "itmsNm": "코미팜",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "089890",
+    "fullNm": "코세스",
+    "itmsNm": "코세스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009730",
+    "fullNm": "코센",
+    "itmsNm": "코센",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "082660",
+    "fullNm": "코스나인",
+    "itmsNm": "코스나인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "192820",
+    "fullNm": "코스맥스보통주",
+    "itmsNm": "코스맥스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "044820",
+    "fullNm": "코스맥스비티아이 주식회사 보통주",
+    "itmsNm": "코스맥스비티아이",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "222040",
+    "fullNm": "코스맥스엔비티",
+    "itmsNm": "코스맥스엔비티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "241710",
+    "fullNm": "코스메카코리아",
+    "itmsNm": "코스메카코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005070",
+    "fullNm": "코스모신소재보통주",
+    "itmsNm": "코스모신소재",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005420",
+    "fullNm": "코스모화학보통주",
+    "itmsNm": "코스모화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "069110",
+    "fullNm": "코스온",
+    "itmsNm": "코스온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "169670",
+    "fullNm": "코스텍시스템",
+    "itmsNm": "코스텍시스템",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "071950",
+    "fullNm": "코아스보통주",
+    "itmsNm": "코아스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "166480",
+    "fullNm": "코아스템켐온",
+    "itmsNm": "코아스템켐온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "045970",
+    "fullNm": "코아시아",
+    "itmsNm": "코아시아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "196450",
+    "fullNm": "코아시아옵틱스",
+    "itmsNm": "코아시아옵틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "029960",
+    "fullNm": "코엔텍",
+    "itmsNm": "코엔텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002025",
+    "fullNm": "코오롱1우선주",
+    "itmsNm": "코오롱우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003075",
+    "fullNm": "코오롱글로벌1우선주",
+    "itmsNm": "코오롱글로벌우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003070",
+    "fullNm": "코오롱글로벌보통주",
+    "itmsNm": "코오롱글로벌",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002020",
+    "fullNm": "코오롱보통주",
+    "itmsNm": "코오롱",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "102940",
+    "fullNm": "코오롱생명과학",
+    "itmsNm": "코오롱생명과학",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "120115",
+    "fullNm": "코오롱인더스트리1우선주",
+    "itmsNm": "코오롱인더우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "120110",
+    "fullNm": "코오롱인더스트리보통주",
+    "itmsNm": "코오롱인더",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "950160",
+    "fullNm": "코오롱티슈진",
+    "itmsNm": "코오롱티슈진",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "138490",
+    "fullNm": "코오롱플라스틱보통주",
+    "itmsNm": "코오롱플라스틱",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "056000",
+    "fullNm": "코원플레이",
+    "itmsNm": "코원플레이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "021240",
+    "fullNm": "코웨이보통주",
+    "itmsNm": "코웨이",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "033290",
+    "fullNm": "코웰패션",
+    "itmsNm": "코웰패션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "056360",
+    "fullNm": "코위버",
+    "itmsNm": "코위버",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "282880",
+    "fullNm": "코윈테크",
+    "itmsNm": "코윈테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "121850",
+    "fullNm": "코이즈",
+    "itmsNm": "코이즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "015710",
+    "fullNm": "코콤",
+    "itmsNm": "코콤",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "052330",
+    "fullNm": "코텍",
+    "itmsNm": "코텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "322780",
+    "fullNm": "코퍼스코리아",
+    "itmsNm": "코퍼스코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036420",
+    "fullNm": "콘텐트리중앙보통주",
+    "itmsNm": "콘텐트리중앙",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "200130",
+    "fullNm": "콜마비앤에이치",
+    "itmsNm": "콜마비앤에이치",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "031820",
+    "fullNm": "콤텍시스템보통주",
+    "itmsNm": "콤텍시스템",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "294570",
+    "fullNm": "쿠콘",
+    "itmsNm": "쿠콘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "192400",
+    "fullNm": "쿠쿠홀딩스보통주",
+    "itmsNm": "쿠쿠홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "284740",
+    "fullNm": "쿠쿠홈시스보통주",
+    "itmsNm": "쿠쿠홈시스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "317690",
+    "fullNm": "퀀타매트릭스",
+    "itmsNm": "퀀타매트릭스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "365270",
+    "fullNm": "큐라클",
+    "itmsNm": "큐라클",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "086460",
+    "fullNm": "큐러블",
+    "itmsNm": "큐러블",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "060280",
+    "fullNm": "큐렉소",
+    "itmsNm": "큐렉소",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "015590",
+    "fullNm": "큐로보통주",
+    "itmsNm": "큐로",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "040350",
+    "fullNm": "큐로컴",
+    "itmsNm": "큐로컴",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "051780",
+    "fullNm": "큐로홀딩스",
+    "itmsNm": "큐로홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "115180",
+    "fullNm": "큐리언트",
+    "itmsNm": "큐리언트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "182360",
+    "fullNm": "큐브엔터테인먼트",
+    "itmsNm": "큐브엔터",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "405100",
+    "fullNm": "큐알티",
+    "itmsNm": "큐알티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066310",
+    "fullNm": "큐에스아이",
+    "itmsNm": "큐에스아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "136660",
+    "fullNm": "큐엠씨",
+    "itmsNm": "큐엠씨",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "016600",
+    "fullNm": "큐캐피탈파트너스",
+    "itmsNm": "큐캐피탈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "26490K",
+    "fullNm": "크라운제과1우선주",
+    "itmsNm": "크라운제과우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "264900",
+    "fullNm": "크라운제과보통주",
+    "itmsNm": "크라운제과",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005745",
+    "fullNm": "크라운해태홀딩스1우선주",
+    "itmsNm": "크라운해태홀딩스우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005740",
+    "fullNm": "크라운해태홀딩스보통주",
+    "itmsNm": "크라운해태홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "259960",
+    "fullNm": "크래프톤보통주",
+    "itmsNm": "크래프톤",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "096240",
+    "fullNm": "크레버스",
+    "itmsNm": "크레버스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "215570",
+    "fullNm": "크로넥스",
+    "itmsNm": "크로넥스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "043590",
+    "fullNm": "크로바하이텍",
+    "itmsNm": "크로바하이텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "114120",
+    "fullNm": "크루셜텍",
+    "itmsNm": "크루셜텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "110790",
+    "fullNm": "크리스에프앤씨",
+    "itmsNm": "크리스에프앤씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "083790",
+    "fullNm": "크리스탈지노믹스",
+    "itmsNm": "크리스탈지노믹스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "045520",
+    "fullNm": "크린앤사이언스",
+    "itmsNm": "크린앤사이언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036170",
+    "fullNm": "클라우드에어",
+    "itmsNm": "클라우드에어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214150",
+    "fullNm": "클래시스",
+    "itmsNm": "클래시스",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "352770",
+    "fullNm": "클리노믹스",
+    "itmsNm": "클리노믹스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "237880",
+    "fullNm": "클리오",
+    "itmsNm": "클리오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "139670",
+    "fullNm": "키네마스터",
+    "itmsNm": "키네마스터",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "020120",
+    "fullNm": "키다리스튜디오보통주",
+    "itmsNm": "키다리스튜디오",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "413600",
+    "fullNm": "키움제6호기업인수목적",
+    "itmsNm": "키움제6호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "433530",
+    "fullNm": "키움제7호기업인수목적",
+    "itmsNm": "키움제7호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039490",
+    "fullNm": "키움증권보통주",
+    "itmsNm": "키움증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "054780",
+    "fullNm": "키이스트",
+    "itmsNm": "키이스트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "336040",
+    "fullNm": "타스컴",
+    "itmsNm": "타스컴",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "219130",
+    "fullNm": "타이거일렉",
+    "itmsNm": "타이거일렉",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "346010",
+    "fullNm": "타이드",
+    "itmsNm": "타이드",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "318660",
+    "fullNm": "타임기술",
+    "itmsNm": "타임기술",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "434190",
+    "fullNm": "탈로스",
+    "itmsNm": "탈로스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "360070",
+    "fullNm": "탑머티리얼",
+    "itmsNm": "탑머티리얼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "180060",
+    "fullNm": "탑선",
+    "itmsNm": "탑선",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "065130",
+    "fullNm": "탑엔지니어링",
+    "itmsNm": "탑엔지니어링",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "134580",
+    "fullNm": "탑코미디어",
+    "itmsNm": "탑코미디어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "014580",
+    "fullNm": "태경비케이보통주",
+    "itmsNm": "태경비케이",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "015890",
+    "fullNm": "태경산업보통주",
+    "itmsNm": "태경산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006890",
+    "fullNm": "태경케미컬보통주",
+    "itmsNm": "태경케미컬",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "023160",
+    "fullNm": "태광",
+    "itmsNm": "태광",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003240",
+    "fullNm": "태광산업보통주",
+    "itmsNm": "태광산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011280",
+    "fullNm": "태림포장보통주",
+    "itmsNm": "태림포장",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "323280",
+    "fullNm": "태성",
+    "itmsNm": "태성",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053620",
+    "fullNm": "태양",
+    "itmsNm": "태양",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004105",
+    "fullNm": "태양금속공업1우선주",
+    "itmsNm": "태양금속우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004100",
+    "fullNm": "태양금속공업보통주",
+    "itmsNm": "태양금속",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "116100",
+    "fullNm": "태양기계 주식회사",
+    "itmsNm": "태양기계",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "009410",
+    "fullNm": "태영건설보통주",
+    "itmsNm": "태영건설",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009415",
+    "fullNm": "태영건설우선주",
+    "itmsNm": "태영건설우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "044490",
+    "fullNm": "태웅",
+    "itmsNm": "태웅",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "124560",
+    "fullNm": "태웅로직스",
+    "itmsNm": "태웅로직스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001420",
+    "fullNm": "태원물산보통주",
+    "itmsNm": "태원물산",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007980",
+    "fullNm": "태평양물산보통주",
+    "itmsNm": "태평양물산",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "191420",
+    "fullNm": "테고사이언스",
+    "itmsNm": "테고사이언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "073640",
+    "fullNm": "테라사이언스",
+    "itmsNm": "테라사이언스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066700",
+    "fullNm": "테라젠이텍스",
+    "itmsNm": "테라젠이텍스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "095610",
+    "fullNm": "테스",
+    "itmsNm": "테스",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "055490",
+    "fullNm": "테이팩스보통주",
+    "itmsNm": "테이팩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "308700",
+    "fullNm": "테크엔",
+    "itmsNm": "테크엔",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "064520",
+    "fullNm": "테크엘",
+    "itmsNm": "테크엘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "089030",
+    "fullNm": "테크윙",
+    "itmsNm": "테크윙",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "258050",
+    "fullNm": "테크트랜스",
+    "itmsNm": "테크트랜스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "054450",
+    "fullNm": "텔레칩스",
+    "itmsNm": "텔레칩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "091440",
+    "fullNm": "텔레필드",
+    "itmsNm": "텔레필드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "078000",
+    "fullNm": "텔코웨어 보통주",
+    "itmsNm": "텔코웨어",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "200230",
+    "fullNm": "텔콘알에프제약",
+    "itmsNm": "텔콘RF제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214420",
+    "fullNm": "토니모리보통주",
+    "itmsNm": "토니모리",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "393210",
+    "fullNm": "토마토시스템",
+    "itmsNm": "토마토시스템",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "215480",
+    "fullNm": "토박스코리아",
+    "itmsNm": "토박스코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "051360",
+    "fullNm": "토비스",
+    "itmsNm": "토비스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "045340",
+    "fullNm": "토탈소프트뱅크",
+    "itmsNm": "토탈소프트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "108230",
+    "fullNm": "톱텍",
+    "itmsNm": "톱텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "079970",
+    "fullNm": "투비소프트",
+    "itmsNm": "투비소프트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "199800",
+    "fullNm": "툴젠",
+    "itmsNm": "툴젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "105550",
+    "fullNm": "트루윈",
+    "itmsNm": "트루윈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "290090",
+    "fullNm": "트윔",
+    "itmsNm": "트윔",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "026150",
+    "fullNm": "특수건설",
+    "itmsNm": "특수건설",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "322180",
+    "fullNm": "티라유텍",
+    "itmsNm": "티라유텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "117730",
+    "fullNm": "티로보틱스",
+    "itmsNm": "티로보틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033830",
+    "fullNm": "티비씨",
+    "itmsNm": "티비씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "057680",
+    "fullNm": "티사이언티픽",
+    "itmsNm": "티사이언티픽",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "204610",
+    "fullNm": "티쓰리엔터테인먼트",
+    "itmsNm": "티쓰리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "064760",
+    "fullNm": "티씨케이",
+    "itmsNm": "티씨케이",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "246710",
+    "fullNm": "티앤알바이오팹",
+    "itmsNm": "티앤알바이오팹",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "340570",
+    "fullNm": "티앤엘",
+    "itmsNm": "티앤엘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "043220",
+    "fullNm": "티에스넥스젠",
+    "itmsNm": "티에스넥스젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "277880",
+    "fullNm": "티에스아이",
+    "itmsNm": "티에스아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "131290",
+    "fullNm": "티에스이",
+    "itmsNm": "티에스이",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "246690",
+    "fullNm": "티에스인베스트먼트",
+    "itmsNm": "TS인베스트먼트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "317240",
+    "fullNm": "티에스트릴리온",
+    "itmsNm": "TS트릴리온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "019180",
+    "fullNm": "티에이치엔보통주",
+    "itmsNm": "티에이치엔",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "425420",
+    "fullNm": "티에프이",
+    "itmsNm": "티에프이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "356860",
+    "fullNm": "티엘비",
+    "itmsNm": "티엘비",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "062860",
+    "fullNm": "티엘아이",
+    "itmsNm": "티엘아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "413300",
+    "fullNm": "티엘엔지니어링",
+    "itmsNm": "티엘엔지니어링",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "002900",
+    "fullNm": "티와이엠보통주",
+    "itmsNm": "TYM",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "36328K",
+    "fullNm": "티와이홀딩스1우선주",
+    "itmsNm": "티와이홀딩스우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "363280",
+    "fullNm": "티와이홀딩스보통주",
+    "itmsNm": "티와이홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "321550",
+    "fullNm": "티움바이오",
+    "itmsNm": "티움바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "091810",
+    "fullNm": "티웨이항공보통주",
+    "itmsNm": "티웨이항공",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004870",
+    "fullNm": "티웨이홀딩스보통주",
+    "itmsNm": "티웨이홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "032540",
+    "fullNm": "티제이미디어",
+    "itmsNm": "TJ미디어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "022220",
+    "fullNm": "티케이지애강",
+    "itmsNm": "TKG애강",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "069260",
+    "fullNm": "티케이지휴켐스보통주",
+    "itmsNm": "TKG휴켐스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "104480",
+    "fullNm": "티케이케미칼",
+    "itmsNm": "티케이케미칼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "081150",
+    "fullNm": "티플랙스",
+    "itmsNm": "티플랙스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "130740",
+    "fullNm": "티피씨",
+    "itmsNm": "티피씨글로벌",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "048770",
+    "fullNm": "티피씨메카트로닉스",
+    "itmsNm": "TPC",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "217880",
+    "fullNm": "틸론",
+    "itmsNm": "틸론",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "084730",
+    "fullNm": "팅크웨어",
+    "itmsNm": "팅크웨어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "046210",
+    "fullNm": "파나진",
+    "itmsNm": "파나진",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "058530",
+    "fullNm": "파나케이아",
+    "itmsNm": "파나케이아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "034230",
+    "fullNm": "파라다이스",
+    "itmsNm": "파라다이스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "033540",
+    "fullNm": "파라텍",
+    "itmsNm": "파라텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "043200",
+    "fullNm": "파루",
+    "itmsNm": "파루",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214450",
+    "fullNm": "파마리서치",
+    "itmsNm": "파마리서치",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "217950",
+    "fullNm": "파마리서치바이오",
+    "itmsNm": "파마리서치바이오",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "208340",
+    "fullNm": "파멥신",
+    "itmsNm": "파멥신",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005690",
+    "fullNm": "파미셀보통주",
+    "itmsNm": "파미셀",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "177830",
+    "fullNm": "파버나인",
+    "itmsNm": "파버나인",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "037070",
+    "fullNm": "파세코",
+    "itmsNm": "파세코",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "150900",
+    "fullNm": "파수",
+    "itmsNm": "파수",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "037030",
+    "fullNm": "파워넷",
+    "itmsNm": "파워넷",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "047310",
+    "fullNm": "파워로직스",
+    "itmsNm": "파워로직스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "266870",
+    "fullNm": "파워풀엑스",
+    "itmsNm": "파워풀엑스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "368770",
+    "fullNm": "파이버프로",
+    "itmsNm": "파이버프로",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "170790",
+    "fullNm": "파이오링크",
+    "itmsNm": "파이오링크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "049120",
+    "fullNm": "파인디앤씨",
+    "itmsNm": "파인디앤씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "038950",
+    "fullNm": "파인디지털",
+    "itmsNm": "파인디지털",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "441270",
+    "fullNm": "파인엠텍",
+    "itmsNm": "파인엠텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "106240",
+    "fullNm": "파인테크닉스",
+    "itmsNm": "파인테크닉스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "131760",
+    "fullNm": "파인텍",
+    "itmsNm": "파인텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "065690",
+    "fullNm": "파커스",
+    "itmsNm": "파커스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "140860",
+    "fullNm": "파크시스템스",
+    "itmsNm": "파크시스템스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "091700",
+    "fullNm": "파트론",
+    "itmsNm": "파트론",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "202960",
+    "fullNm": "판도라티비",
+    "itmsNm": "판도라티비",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "032800",
+    "fullNm": "판타지오",
+    "itmsNm": "판타지오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "318010",
+    "fullNm": "팜스빌",
+    "itmsNm": "팜스빌",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036580",
+    "fullNm": "팜스코보통주",
+    "itmsNm": "팜스코",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "027710",
+    "fullNm": "팜스토리",
+    "itmsNm": "팜스토리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004720",
+    "fullNm": "팜젠사이언스보통주",
+    "itmsNm": "팜젠사이언스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "225590",
+    "fullNm": "패션플랫폼",
+    "itmsNm": "패션플랫폼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054300",
+    "fullNm": "팬스타엔터프라이즈",
+    "itmsNm": "팬스타엔터프라이즈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "068050",
+    "fullNm": "팬엔터테인먼트",
+    "itmsNm": "팬엔터테인먼트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "028670",
+    "fullNm": "팬오션보통주",
+    "itmsNm": "팬오션",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "222110",
+    "fullNm": "팬젠",
+    "itmsNm": "팬젠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010820",
+    "fullNm": "퍼스텍보통주",
+    "itmsNm": "퍼스텍",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "016800",
+    "fullNm": "퍼시스보통주",
+    "itmsNm": "퍼시스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "263750",
+    "fullNm": "펄어비스",
+    "itmsNm": "펄어비스",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "251970",
+    "fullNm": "펌텍코리아",
+    "itmsNm": "펌텍코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001020",
+    "fullNm": "페이퍼코리아보통주",
+    "itmsNm": "페이퍼코리아",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "327610",
+    "fullNm": "펨토바이오메드",
+    "itmsNm": "펨토바이오메드",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "168360",
+    "fullNm": "펨트론",
+    "itmsNm": "펨트론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "087010",
+    "fullNm": "펩트론",
+    "itmsNm": "펩트론",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "090080",
+    "fullNm": "평화산업 주식회사 보통주",
+    "itmsNm": "평화산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "010770",
+    "fullNm": "평화홀딩스보통주",
+    "itmsNm": "평화홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "119500",
+    "fullNm": "포메탈",
+    "itmsNm": "포메탈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "389140",
+    "fullNm": "포바이포",
+    "itmsNm": "포바이포",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "058430",
+    "fullNm": "포스코스틸리온보통주",
+    "itmsNm": "포스코스틸리온",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "022100",
+    "fullNm": "포스코아이씨티",
+    "itmsNm": "포스코 ICT",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "047050",
+    "fullNm": "포스코인터내셔널보통주",
+    "itmsNm": "포스코인터내셔널",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003670",
+    "fullNm": "포스코케미칼보통주",
+    "itmsNm": "포스코케미칼",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005490",
+    "fullNm": "포스코홀딩스보통주",
+    "itmsNm": "POSCO홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "189690",
+    "fullNm": "포시에스",
+    "itmsNm": "포시에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "318020",
+    "fullNm": "포인트모바일",
+    "itmsNm": "포인트모바일",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "256630",
+    "fullNm": "포인트엔지니어링",
+    "itmsNm": "포인트엔지니어링",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "331380",
+    "fullNm": "포커스에이치엔에스",
+    "itmsNm": "포커스에이치엔에스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "234100",
+    "fullNm": "폴라리스세원",
+    "itmsNm": "폴라리스세원",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "041020",
+    "fullNm": "폴라리스오피스",
+    "itmsNm": "폴라리스오피스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "114630",
+    "fullNm": "폴라리스우노",
+    "itmsNm": "폴라리스우노",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "290720",
+    "fullNm": "푸드나무",
+    "itmsNm": "푸드나무",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005670",
+    "fullNm": "푸드웰",
+    "itmsNm": "푸드웰",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "094940",
+    "fullNm": "푸른기술",
+    "itmsNm": "푸른기술",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "007330",
+    "fullNm": "푸른상호저축은행",
+    "itmsNm": "푸른저축은행",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "017810",
+    "fullNm": "풀무원보통주",
+    "itmsNm": "풀무원",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "093380",
+    "fullNm": "풍강",
+    "itmsNm": "풍강",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "023900",
+    "fullNm": "풍국주정공업",
+    "itmsNm": "풍국주정",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "103140",
+    "fullNm": "풍산 보통주",
+    "itmsNm": "풍산",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005810",
+    "fullNm": "풍산홀딩스보통주",
+    "itmsNm": "풍산홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "371950",
+    "fullNm": "풍원정밀",
+    "itmsNm": "풍원정밀",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "370090",
+    "fullNm": "퓨런티어",
+    "itmsNm": "퓨런티어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "341170",
+    "fullNm": "퓨쳐메디신",
+    "itmsNm": "퓨쳐메디신",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "220100",
+    "fullNm": "퓨쳐켐",
+    "itmsNm": "퓨쳐켐",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "035200",
+    "fullNm": "프럼파스트",
+    "itmsNm": "프럼파스트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "334970",
+    "fullNm": "프레스티지바이오로직스",
+    "itmsNm": "프레스티지바이오로직스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "950210",
+    "fullNm": "프레스티지바이오파마KDR",
+    "itmsNm": "프레스티지바이오파마",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "203690",
+    "fullNm": "프로스테믹스",
+    "itmsNm": "프로스테믹스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "321260",
+    "fullNm": "프로이천",
+    "itmsNm": "프로이천",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "303360",
+    "fullNm": "프로테옴텍",
+    "itmsNm": "프로테옴텍",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "053610",
+    "fullNm": "프로텍",
+    "itmsNm": "프로텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "377220",
+    "fullNm": "프롬바이오",
+    "itmsNm": "프롬바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "335810",
+    "fullNm": "프리시젼바이오",
+    "itmsNm": "프리시젼바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053160",
+    "fullNm": "프리엠스",
+    "itmsNm": "프리엠스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "405000",
+    "fullNm": "플라즈맵",
+    "itmsNm": "플라즈맵",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "041590",
+    "fullNm": "플래스크",
+    "itmsNm": "플래스크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "367000",
+    "fullNm": "플래티어",
+    "itmsNm": "플래티어",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "075130",
+    "fullNm": "플랜티넷",
+    "itmsNm": "플랜티넷",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "222670",
+    "fullNm": "플럼라인생명과학",
+    "itmsNm": "플럼라인생명과학",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "009810",
+    "fullNm": "플레이그램보통주",
+    "itmsNm": "플레이그램",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "237820",
+    "fullNm": "플레이디",
+    "itmsNm": "플레이디",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "023770",
+    "fullNm": "플레이위드",
+    "itmsNm": "플레이위드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "300080",
+    "fullNm": "플리토",
+    "itmsNm": "플리토",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "150440",
+    "fullNm": "피노텍",
+    "itmsNm": "피노텍",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "032580",
+    "fullNm": "피델릭스",
+    "itmsNm": "피델릭스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "051380",
+    "fullNm": "피씨디렉트",
+    "itmsNm": "피씨디렉트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "241820",
+    "fullNm": "피씨엘",
+    "itmsNm": "피씨엘",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "178920",
+    "fullNm": "피아이첨단소재보통주",
+    "itmsNm": "PI첨단소재",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "237750",
+    "fullNm": "피앤씨테크",
+    "itmsNm": "피앤씨테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "024850",
+    "fullNm": "피에스엠씨",
+    "itmsNm": "피에스엠씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "319660",
+    "fullNm": "피에스케이",
+    "itmsNm": "피에스케이",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "031980",
+    "fullNm": "피에스케이홀딩스",
+    "itmsNm": "피에스케이홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002230",
+    "fullNm": "피에스텍",
+    "itmsNm": "피에스텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "057880",
+    "fullNm": "피에이치씨",
+    "itmsNm": "피에이치씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "043370",
+    "fullNm": "피에이치에이",
+    "itmsNm": "피에이치에이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "242350",
+    "fullNm": "피엔아이컴퍼니",
+    "itmsNm": "피엔아이컴퍼니",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "239890",
+    "fullNm": "피엔에이치테크",
+    "itmsNm": "피엔에이치테크",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "347740",
+    "fullNm": "피엔케이피부임상연구센타",
+    "itmsNm": "피엔케이피부임상연구센타",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "137400",
+    "fullNm": "피엔티",
+    "itmsNm": "피엔티",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "024940",
+    "fullNm": "피엔풍년",
+    "itmsNm": "PN풍년",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "128660",
+    "fullNm": "피제이메탈",
+    "itmsNm": "피제이메탈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006140",
+    "fullNm": "피제이전자",
+    "itmsNm": "피제이전자",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "376180",
+    "fullNm": "피코그램",
+    "itmsNm": "피코그램",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "304840",
+    "fullNm": "피플바이오",
+    "itmsNm": "피플바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "062970",
+    "fullNm": "피피아이",
+    "itmsNm": "피피아이",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "087600",
+    "fullNm": "픽셀플러스",
+    "itmsNm": "픽셀플러스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "291810",
+    "fullNm": "핀텔",
+    "itmsNm": "핀텔",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "161580",
+    "fullNm": "필옵틱스",
+    "itmsNm": "필옵틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "347770",
+    "fullNm": "핌스",
+    "itmsNm": "핌스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "163730",
+    "fullNm": "핑거",
+    "itmsNm": "핑거",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "417180",
+    "fullNm": "핑거스토리",
+    "itmsNm": "핑거스토리",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "343510",
+    "fullNm": "하나금융16호기업인수목적",
+    "itmsNm": "하나금융16호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "388220",
+    "fullNm": "하나금융19호기업인수목적",
+    "itmsNm": "하나금융19호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "400560",
+    "fullNm": "하나금융20호기업인수목적",
+    "itmsNm": "하나금융20호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "406760",
+    "fullNm": "하나금융21호기업인수목적",
+    "itmsNm": "하나금융21호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "418170",
+    "fullNm": "하나금융22호기업인수목적",
+    "itmsNm": "하나금융22호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "427950",
+    "fullNm": "하나금융23호기업인수목적",
+    "itmsNm": "하나금융23호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "430230",
+    "fullNm": "하나금융24호기업인수목적",
+    "itmsNm": "하나금융24호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "435620",
+    "fullNm": "하나금융25호기업인수목적",
+    "itmsNm": "하나금융25호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "086790",
+    "fullNm": "하나금융지주보통주",
+    "itmsNm": "하나금융지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "299030",
+    "fullNm": "하나기술",
+    "itmsNm": "하나기술",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "067310",
+    "fullNm": "하나마이크론",
+    "itmsNm": "하나마이크론",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "372290",
+    "fullNm": "하나머스트7호기업인수목적",
+    "itmsNm": "하나머스트7호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "166090",
+    "fullNm": "하나머티리얼즈",
+    "itmsNm": "하나머티리얼즈",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "293480",
+    "fullNm": "하나제약보통주",
+    "itmsNm": "하나제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "039130",
+    "fullNm": "하나투어보통주",
+    "itmsNm": "하나투어",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "136480",
+    "fullNm": "하림",
+    "itmsNm": "하림",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "003380",
+    "fullNm": "하림지주",
+    "itmsNm": "하림지주",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "101670",
+    "fullNm": "하이드로리튬",
+    "itmsNm": "하이드로리튬",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "365590",
+    "fullNm": "하이딥",
+    "itmsNm": "하이딥",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "149980",
+    "fullNm": "하이로닉",
+    "itmsNm": "하이로닉",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "013030",
+    "fullNm": "하이록코리아",
+    "itmsNm": "하이록코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "352820",
+    "fullNm": "하이브보통주",
+    "itmsNm": "하이브",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "126700",
+    "fullNm": "하이비젼시스템",
+    "itmsNm": "하이비젼시스템",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "106080",
+    "fullNm": "하이소닉",
+    "itmsNm": "하이소닉",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "071090",
+    "fullNm": "하이스틸 보통주",
+    "itmsNm": "하이스틸",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "377400",
+    "fullNm": "하이제6호기업인수목적",
+    "itmsNm": "하이제6호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "400840",
+    "fullNm": "하이제7호기업인수목적",
+    "itmsNm": "하이제7호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "221840",
+    "fullNm": "하이즈항공",
+    "itmsNm": "하이즈항공",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "106190",
+    "fullNm": "하이텍팜",
+    "itmsNm": "하이텍팜",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "019490",
+    "fullNm": "하이트론씨스템즈보통주",
+    "itmsNm": "하이트론",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000087",
+    "fullNm": "하이트진로2우선주(신형)",
+    "itmsNm": "하이트진로2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000080",
+    "fullNm": "하이트진로보통주",
+    "itmsNm": "하이트진로",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000145",
+    "fullNm": "하이트진로홀딩스1우선주",
+    "itmsNm": "하이트진로홀딩스우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000140",
+    "fullNm": "하이트진로홀딩스보통주",
+    "itmsNm": "하이트진로홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "373200",
+    "fullNm": "하인크코리아",
+    "itmsNm": "하인크코리아",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "066130",
+    "fullNm": "하츠",
+    "itmsNm": "하츠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004590",
+    "fullNm": "한국가구",
+    "itmsNm": "한국가구",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "036460",
+    "fullNm": "한국가스공사보통주",
+    "itmsNm": "한국가스공사",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "039340",
+    "fullNm": "한국경제티브이",
+    "itmsNm": "한국경제TV",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005430",
+    "fullNm": "한국공항보통주",
+    "itmsNm": "한국공항",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "034950",
+    "fullNm": "한국기업평가",
+    "itmsNm": "한국기업평가",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010040",
+    "fullNm": "한국내화보통주",
+    "itmsNm": "한국내화",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "025540",
+    "fullNm": "한국단자공업보통주",
+    "itmsNm": "한국단자",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "222980",
+    "fullNm": "한국맥널티",
+    "itmsNm": "한국맥널티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "331660",
+    "fullNm": "한국미라클피플사",
+    "itmsNm": "한국미라클피플사",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "096300",
+    "fullNm": "한국베트남부동산개발특별자산1호투자회사",
+    "itmsNm": "베트남개발1",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "256840",
+    "fullNm": "한국비엔씨",
+    "itmsNm": "한국비엔씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004090",
+    "fullNm": "한국석유공업보통주",
+    "itmsNm": "한국석유",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "025550",
+    "fullNm": "한국선재",
+    "itmsNm": "한국선재",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002200",
+    "fullNm": "한국수출포장공업보통주",
+    "itmsNm": "한국수출포장",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002960",
+    "fullNm": "한국쉘석유보통주",
+    "itmsNm": "한국쉘석유",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "017890",
+    "fullNm": "한국알콜산업",
+    "itmsNm": "한국알콜",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000240",
+    "fullNm": "한국앤컴퍼니보통주",
+    "itmsNm": "한국앤컴퍼니",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "033270",
+    "fullNm": "한국유나이티드제약 보통주",
+    "itmsNm": "유나이티드제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "080720",
+    "fullNm": "한국유니온제약",
+    "itmsNm": "한국유니온제약",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "123890",
+    "fullNm": "한국자산신탁보통주",
+    "itmsNm": "한국자산신탁",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "015760",
+    "fullNm": "한국전력공사보통주",
+    "itmsNm": "한국전력",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "052690",
+    "fullNm": "한국전력기술 보통주",
+    "itmsNm": "한전기술",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "063570",
+    "fullNm": "한국전자금융",
+    "itmsNm": "한국전자금융",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "041460",
+    "fullNm": "한국전자인증",
+    "itmsNm": "한국전자인증",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "006200",
+    "fullNm": "한국전자홀딩스보통주",
+    "itmsNm": "한국전자홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "101680",
+    "fullNm": "한국정밀기계",
+    "itmsNm": "한국정밀기계",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039740",
+    "fullNm": "한국정보공학",
+    "itmsNm": "한국정보공학",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053300",
+    "fullNm": "한국정보인증",
+    "itmsNm": "한국정보인증",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "025770",
+    "fullNm": "한국정보통신",
+    "itmsNm": "한국정보통신",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "409570",
+    "fullNm": "한국제10호기업인수목적 주식회사",
+    "itmsNm": "한국제10호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "436610",
+    "fullNm": "한국제11호기업인수목적",
+    "itmsNm": "한국제11호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009540",
+    "fullNm": "한국조선해양보통주",
+    "itmsNm": "한국조선해양",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "023350",
+    "fullNm": "한국종합기술보통주",
+    "itmsNm": "한국종합기술",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "025890",
+    "fullNm": "한국주강보통주",
+    "itmsNm": "한국주강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000970",
+    "fullNm": "한국주철관공업보통주",
+    "itmsNm": "한국주철관",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "104700",
+    "fullNm": "한국철강보통주",
+    "itmsNm": "한국철강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "017960",
+    "fullNm": "한국카본보통주",
+    "itmsNm": "한국카본",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "023760",
+    "fullNm": "한국캐피탈",
+    "itmsNm": "한국캐피탈",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "054040",
+    "fullNm": "한국컴퓨터",
+    "itmsNm": "한국컴퓨터",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "161890",
+    "fullNm": "한국콜마보통주",
+    "itmsNm": "한국콜마",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "024720",
+    "fullNm": "한국콜마홀딩스보통주",
+    "itmsNm": "한국콜마홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "021650",
+    "fullNm": "한국큐빅",
+    "itmsNm": "한국큐빅",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "161390",
+    "fullNm": "한국타이어앤테크놀로지보통주",
+    "itmsNm": "한국타이어앤테크놀로지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "053590",
+    "fullNm": "한국테크놀로지",
+    "itmsNm": "한국테크놀로지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "034830",
+    "fullNm": "한국토지신탁보통주",
+    "itmsNm": "한국토지신탁",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "152550",
+    "fullNm": "한국투자ANKOR유전해외자원개발특별자산투자회사1호(지분증권)",
+    "itmsNm": "한국ANKOR유전",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "168490",
+    "fullNm": "한국투자Parallel유전해외자원개발특별자산투자회사1호",
+    "itmsNm": "한국패러랠",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "071055",
+    "fullNm": "한국투자금융지주1우선주",
+    "itmsNm": "한국금융지주우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "071050",
+    "fullNm": "한국투자금융지주보통주",
+    "itmsNm": "한국금융지주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007280",
+    "fullNm": "한국특강보통주",
+    "itmsNm": "한국특강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "032300",
+    "fullNm": "한국파마",
+    "itmsNm": "한국파마",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "037230",
+    "fullNm": "한국팩키지",
+    "itmsNm": "한국팩키지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010100",
+    "fullNm": "한국프랜지공업보통주",
+    "itmsNm": "한국프랜지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "047810",
+    "fullNm": "한국항공우주산업보통주",
+    "itmsNm": "한국항공우주",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "123690",
+    "fullNm": "한국화장품보통주",
+    "itmsNm": "한국화장품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003350",
+    "fullNm": "한국화장품제조보통주",
+    "itmsNm": "한국화장품제조",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "030520",
+    "fullNm": "한글과컴퓨터",
+    "itmsNm": "한글과컴퓨터",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "052600",
+    "fullNm": "한네트",
+    "itmsNm": "한네트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "011500",
+    "fullNm": "한농화성보통주",
+    "itmsNm": "한농화성",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "002390",
+    "fullNm": "한독보통주",
+    "itmsNm": "한독",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "256150",
+    "fullNm": "한독크린텍",
+    "itmsNm": "한독크린텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "092460",
+    "fullNm": "한라아이엠에스",
+    "itmsNm": "한라IMS",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "053690",
+    "fullNm": "한미글로벌건축사사무소보통주",
+    "itmsNm": "한미글로벌",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "042700",
+    "fullNm": "한미반도체보통주",
+    "itmsNm": "한미반도체",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "008930",
+    "fullNm": "한미사이언스보통주",
+    "itmsNm": "한미사이언스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "128940",
+    "fullNm": "한미약품보통주",
+    "itmsNm": "한미약품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "047080",
+    "fullNm": "한빛소프트",
+    "itmsNm": "한빛소프트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009240",
+    "fullNm": "한샘보통주",
+    "itmsNm": "한샘",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "020000",
+    "fullNm": "한섬보통주",
+    "itmsNm": "한섬",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003680",
+    "fullNm": "한성기업보통주",
+    "itmsNm": "한성기업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "105630",
+    "fullNm": "한세실업보통주",
+    "itmsNm": "한세실업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "069640",
+    "fullNm": "한세엠케이보통주",
+    "itmsNm": "한세엠케이",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "016450",
+    "fullNm": "한세예스24홀딩스보통주",
+    "itmsNm": "한세예스24홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "010420",
+    "fullNm": "한솔PNS보통주",
+    "itmsNm": "한솔PNS",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009180",
+    "fullNm": "한솔로지스틱스보통주",
+    "itmsNm": "한솔로지스틱스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "114810",
+    "fullNm": "한솔아이원스",
+    "itmsNm": "한솔아이원스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "070590",
+    "fullNm": "한솔인티큐브",
+    "itmsNm": "한솔인티큐브",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "213500",
+    "fullNm": "한솔제지보통주",
+    "itmsNm": "한솔제지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "014680",
+    "fullNm": "한솔케미칼보통주",
+    "itmsNm": "한솔케미칼",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004710",
+    "fullNm": "한솔테크닉스보통주",
+    "itmsNm": "한솔테크닉스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004150",
+    "fullNm": "한솔홀딩스보통주",
+    "itmsNm": "한솔홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "025750",
+    "fullNm": "한솔홈데코보통주",
+    "itmsNm": "한솔홈데코",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "226440",
+    "fullNm": "한송네오텍",
+    "itmsNm": "한송네오텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "042520",
+    "fullNm": "한스바이오메드",
+    "itmsNm": "한스바이오메드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "004960",
+    "fullNm": "한신공영보통주",
+    "itmsNm": "한신공영",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011700",
+    "fullNm": "한신기계공업보통주",
+    "itmsNm": "한신기계",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "078350",
+    "fullNm": "한양디지텍",
+    "itmsNm": "한양디지텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "045100",
+    "fullNm": "한양이엔지",
+    "itmsNm": "한양이엔지",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "001755",
+    "fullNm": "한양증권1우선주",
+    "itmsNm": "한양증권우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001750",
+    "fullNm": "한양증권보통주",
+    "itmsNm": "한양증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "018880",
+    "fullNm": "한온시스템보통주",
+    "itmsNm": "한온시스템",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009420",
+    "fullNm": "한올바이오파마보통주",
+    "itmsNm": "한올바이오파마",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "014130",
+    "fullNm": "한익스프레스보통주",
+    "itmsNm": "한익스프레스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "024740",
+    "fullNm": "한일단조공업",
+    "itmsNm": "한일단조",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005860",
+    "fullNm": "한일사료",
+    "itmsNm": "한일사료",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "300720",
+    "fullNm": "한일시멘트보통주",
+    "itmsNm": "한일시멘트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "123840",
+    "fullNm": "한일진공",
+    "itmsNm": "한일진공",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002220",
+    "fullNm": "한일철강보통주",
+    "itmsNm": "한일철강",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006390",
+    "fullNm": "한일현대시멘트보통주",
+    "itmsNm": "한일현대시멘트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003300",
+    "fullNm": "한일홀딩스보통주",
+    "itmsNm": "한일홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "007770",
+    "fullNm": "한일화학공업",
+    "itmsNm": "한일화학",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "051600",
+    "fullNm": "한전KPS 보통주",
+    "itmsNm": "한전KPS",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "130660",
+    "fullNm": "한전산업개발보통주",
+    "itmsNm": "한전산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "107640",
+    "fullNm": "한중엔시에스",
+    "itmsNm": "한중엔시에스",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "002320",
+    "fullNm": "한진보통주",
+    "itmsNm": "한진",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003480",
+    "fullNm": "한진중공업홀딩스보통주",
+    "itmsNm": "한진중공업홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "18064K",
+    "fullNm": "한진칼1우선주",
+    "itmsNm": "한진칼우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "180640",
+    "fullNm": "한진칼보통주",
+    "itmsNm": "한진칼",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005110",
+    "fullNm": "한창보통주",
+    "itmsNm": "한창",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "079170",
+    "fullNm": "한창산업",
+    "itmsNm": "한창산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "009460",
+    "fullNm": "한창제지보통주",
+    "itmsNm": "한창제지",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "372910",
+    "fullNm": "한컴라이프케어보통주",
+    "itmsNm": "한컴라이프케어",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "054920",
+    "fullNm": "한컴위드",
+    "itmsNm": "한컴위드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002680",
+    "fullNm": "한탑",
+    "itmsNm": "한탑",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000885",
+    "fullNm": "한화1우선주",
+    "itmsNm": "한화우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "00088K",
+    "fullNm": "한화3우선주(신형)",
+    "itmsNm": "한화3우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000880",
+    "fullNm": "한화보통주",
+    "itmsNm": "한화",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "088350",
+    "fullNm": "한화생명보험보통주",
+    "itmsNm": "한화생명",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000370",
+    "fullNm": "한화손해보험보통주",
+    "itmsNm": "한화손해보험",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009835",
+    "fullNm": "한화솔루션1우선주",
+    "itmsNm": "한화솔루션우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "009830",
+    "fullNm": "한화솔루션보통주",
+    "itmsNm": "한화솔루션",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "272210",
+    "fullNm": "한화시스템보통주",
+    "itmsNm": "한화시스템",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012450",
+    "fullNm": "한화에어로스페이스보통주",
+    "itmsNm": "한화에어로스페이스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003535",
+    "fullNm": "한화투자증권1우선주",
+    "itmsNm": "한화투자증권우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003530",
+    "fullNm": "한화투자증권보통주",
+    "itmsNm": "한화투자증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "386580",
+    "fullNm": "한화플러스제2호기업인수목적",
+    "itmsNm": "한화플러스제2호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "430460",
+    "fullNm": "한화플러스제3호기업인수목적",
+    "itmsNm": "한화플러스제3호스팩",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "195870",
+    "fullNm": "해성디에스보통주",
+    "itmsNm": "해성디에스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "034810",
+    "fullNm": "해성산업",
+    "itmsNm": "해성산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "03481K",
+    "fullNm": "해성산업1우선주",
+    "itmsNm": "해성산업1우",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "076610",
+    "fullNm": "해성옵틱스",
+    "itmsNm": "해성옵틱스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "059270",
+    "fullNm": "해성티피씨",
+    "itmsNm": "해성티피씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "101530",
+    "fullNm": "해태제과식품주식회사",
+    "itmsNm": "해태제과식품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "220180",
+    "fullNm": "핸디소프트",
+    "itmsNm": "핸디소프트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "143210",
+    "fullNm": "핸즈코퍼레이션보통주",
+    "itmsNm": "핸즈코퍼레이션",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "900270",
+    "fullNm": "헝셩그룹유한회사",
+    "itmsNm": "헝셩그룹",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "214180",
+    "fullNm": "헥토이노베이션",
+    "itmsNm": "헥토이노베이션",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "234340",
+    "fullNm": "헥토파이낸셜",
+    "itmsNm": "헥토파이낸셜",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "084990",
+    "fullNm": "헬릭스미스",
+    "itmsNm": "헬릭스미스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000725",
+    "fullNm": "현대건설1우선주",
+    "itmsNm": "현대건설우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "267270",
+    "fullNm": "현대건설기계보통주",
+    "itmsNm": "현대건설기계",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000720",
+    "fullNm": "현대건설보통주",
+    "itmsNm": "현대건설",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "170030",
+    "fullNm": "현대공업",
+    "itmsNm": "현대공업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005440",
+    "fullNm": "현대그린푸드보통주",
+    "itmsNm": "현대그린푸드",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "086280",
+    "fullNm": "현대글로비스보통주",
+    "itmsNm": "현대글로비스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "042670",
+    "fullNm": "현대두산인프라코어보통주",
+    "itmsNm": "현대두산인프라코어",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "064350",
+    "fullNm": "현대로템보통주",
+    "itmsNm": "현대로템",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "079430",
+    "fullNm": "현대리바트보통주",
+    "itmsNm": "현대리바트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "012330",
+    "fullNm": "현대모비스보통주",
+    "itmsNm": "현대모비스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "319400",
+    "fullNm": "현대무벡스",
+    "itmsNm": "현대무벡스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010620",
+    "fullNm": "현대미포조선보통주",
+    "itmsNm": "현대미포조선",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "052260",
+    "fullNm": "현대바이오랜드",
+    "itmsNm": "현대바이오랜드",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "048410",
+    "fullNm": "현대바이오사이언스",
+    "itmsNm": "현대바이오",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "069960",
+    "fullNm": "현대백화점보통주",
+    "itmsNm": "현대백화점",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004565",
+    "fullNm": "현대비앤지스틸1우선주",
+    "itmsNm": "현대비앤지스틸우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004560",
+    "fullNm": "현대비앤지스틸보통주",
+    "itmsNm": "현대비앤지스틸",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004310",
+    "fullNm": "현대약품보통주",
+    "itmsNm": "현대약품",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "322000",
+    "fullNm": "현대에너지솔루션보통주",
+    "itmsNm": "현대에너지솔루션",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "041440",
+    "fullNm": "현대에버다임",
+    "itmsNm": "현대에버다임",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039010",
+    "fullNm": "현대에이치티",
+    "itmsNm": "현대에이치티",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "017800",
+    "fullNm": "현대엘리베이터보통주",
+    "itmsNm": "현대엘리베이",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "307950",
+    "fullNm": "현대오토에버보통주",
+    "itmsNm": "현대오토에버",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011210",
+    "fullNm": "현대위아보통주",
+    "itmsNm": "현대위아",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "090850",
+    "fullNm": "현대이지웰",
+    "itmsNm": "현대이지웰",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "267260",
+    "fullNm": "현대일렉트릭보통주",
+    "itmsNm": "현대일렉트릭",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005385",
+    "fullNm": "현대자동차1우선주",
+    "itmsNm": "현대차우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005387",
+    "fullNm": "현대자동차2우선주(신형)",
+    "itmsNm": "현대차2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005389",
+    "fullNm": "현대자동차3우선주(신형)",
+    "itmsNm": "현대차3우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "005380",
+    "fullNm": "현대자동차보통주",
+    "itmsNm": "현대차",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004020",
+    "fullNm": "현대제철 보통주",
+    "itmsNm": "현대제철",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "329180",
+    "fullNm": "현대중공업보통주",
+    "itmsNm": "현대중공업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001500",
+    "fullNm": "현대차증권보통주",
+    "itmsNm": "현대차증권",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "011760",
+    "fullNm": "현대코퍼레이션보통주",
+    "itmsNm": "현대코퍼레이션",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "227840",
+    "fullNm": "현대코퍼레이션홀딩스보통주",
+    "itmsNm": "현대코퍼레이션홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "126560",
+    "fullNm": "현대퓨처넷보통주",
+    "itmsNm": "현대퓨처넷",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "001450",
+    "fullNm": "현대해상화재보험보통주",
+    "itmsNm": "현대해상",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "057050",
+    "fullNm": "현대홈쇼핑보통주",
+    "itmsNm": "현대홈쇼핑",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "092300",
+    "fullNm": "현우산업",
+    "itmsNm": "현우산업",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "138360",
+    "fullNm": "협진",
+    "itmsNm": "협진",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "011080",
+    "fullNm": "형지아이앤씨",
+    "itmsNm": "형지I&C",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "093240",
+    "fullNm": "형지엘리트보통주",
+    "itmsNm": "형지엘리트",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003010",
+    "fullNm": "혜인보통주",
+    "itmsNm": "혜인",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "111110",
+    "fullNm": "호전실업보통주",
+    "itmsNm": "호전실업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "008775",
+    "fullNm": "호텔신라1우선주",
+    "itmsNm": "호텔신라우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "008770",
+    "fullNm": "호텔신라보통주",
+    "itmsNm": "호텔신라",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "060560",
+    "fullNm": "홈센타홀딩스",
+    "itmsNm": "홈센타홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "064240",
+    "fullNm": "홈캐스트",
+    "itmsNm": "홈캐스트",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "039610",
+    "fullNm": "화성밸브",
+    "itmsNm": "화성밸브",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "002460",
+    "fullNm": "화성산업보통주",
+    "itmsNm": "화성산업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "378850",
+    "fullNm": "화승알앤에이보통주",
+    "itmsNm": "화승알앤에이",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "241590",
+    "fullNm": "화승엔터프라이즈보통주",
+    "itmsNm": "화승엔터프라이즈",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "006060",
+    "fullNm": "화승인더스트리보통주",
+    "itmsNm": "화승인더",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "013520",
+    "fullNm": "화승코퍼레이션보통주",
+    "itmsNm": "화승코퍼레이션",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "010690",
+    "fullNm": "화신보통주",
+    "itmsNm": "화신",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "126640",
+    "fullNm": "화신정공",
+    "itmsNm": "화신정공",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "133820",
+    "fullNm": "화인베스틸보통주",
+    "itmsNm": "화인베스틸",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "061250",
+    "fullNm": "화일약품",
+    "itmsNm": "화일약품",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010660",
+    "fullNm": "화천기계보통주",
+    "itmsNm": "화천기계",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000850",
+    "fullNm": "화천기공보통주",
+    "itmsNm": "화천기공",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "016580",
+    "fullNm": "환인제약보통주",
+    "itmsNm": "환인제약",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "032560",
+    "fullNm": "황금에스티보통주",
+    "itmsNm": "황금에스티",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "004800",
+    "fullNm": "효성보통주",
+    "itmsNm": "효성",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "094280",
+    "fullNm": "효성아이티엑스 보통주",
+    "itmsNm": "효성ITX",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "097870",
+    "fullNm": "효성오앤비",
+    "itmsNm": "효성오앤비",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "298040",
+    "fullNm": "효성중공업보통주",
+    "itmsNm": "효성중공업",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "298050",
+    "fullNm": "효성첨단소재보통주",
+    "itmsNm": "효성첨단소재",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "298020",
+    "fullNm": "효성티앤씨보통주",
+    "itmsNm": "효성티앤씨",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "298000",
+    "fullNm": "효성화학보통주",
+    "itmsNm": "효성화학",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "093370",
+    "fullNm": "후성 보통주",
+    "itmsNm": "후성",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "081660",
+    "fullNm": "휠라홀딩스보통주",
+    "itmsNm": "휠라홀딩스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "290270",
+    "fullNm": "휴네시온",
+    "itmsNm": "휴네시온",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005870",
+    "fullNm": "휴니드테크놀러지스보통주",
+    "itmsNm": "휴니드",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "353190",
+    "fullNm": "휴럼",
+    "itmsNm": "휴럼",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "192410",
+    "fullNm": "휴림네트웍스",
+    "itmsNm": "휴림네트웍스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "090710",
+    "fullNm": "휴림로봇",
+    "itmsNm": "휴림로봇",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "205470",
+    "fullNm": "휴마시스",
+    "itmsNm": "휴마시스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "115160",
+    "fullNm": "휴맥스",
+    "itmsNm": "휴맥스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "028080",
+    "fullNm": "휴맥스홀딩스",
+    "itmsNm": "휴맥스홀딩스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "032860",
+    "fullNm": "휴먼엔",
+    "itmsNm": "휴먼엔",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "200670",
+    "fullNm": "휴메딕스",
+    "itmsNm": "휴메딕스",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "212310",
+    "fullNm": "휴벡셀",
+    "itmsNm": "휴벡셀",
+    "mrktCtg": "KONEX"
+  },
+  {
+    "srtnCd": "079980",
+    "fullNm": "휴비스보통주",
+    "itmsNm": "휴비스",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "065510",
+    "fullNm": "휴비츠",
+    "itmsNm": "휴비츠",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "215090",
+    "fullNm": "휴센텍",
+    "itmsNm": "휴센텍",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "005010",
+    "fullNm": "휴스틸보통주",
+    "itmsNm": "휴스틸",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "263920",
+    "fullNm": "휴엠앤씨",
+    "itmsNm": "휴엠앤씨",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "243070",
+    "fullNm": "휴온스",
+    "itmsNm": "휴온스",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "084110",
+    "fullNm": "휴온스글로벌",
+    "itmsNm": "휴온스글로벌",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "145020",
+    "fullNm": "휴젤",
+    "itmsNm": "휴젤",
+    "mrktCtg": "KOSDAQ GLOBAL"
+  },
+  {
+    "srtnCd": "024060",
+    "fullNm": "흥구석유",
+    "itmsNm": "흥구석유",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "010240",
+    "fullNm": "흥국",
+    "itmsNm": "흥국",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "189980",
+    "fullNm": "흥국에프엔비",
+    "itmsNm": "흥국에프엔비",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "000545",
+    "fullNm": "흥국화재해상보험1우선주",
+    "itmsNm": "흥국화재우",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000547",
+    "fullNm": "흥국화재해상보험2우선주(신형)",
+    "itmsNm": "흥국화재2우B",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "000540",
+    "fullNm": "흥국화재해상보험보통주",
+    "itmsNm": "흥국화재",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "003280",
+    "fullNm": "흥아해운보통주",
+    "itmsNm": "흥아해운",
+    "mrktCtg": "KOSPI"
+  },
+  {
+    "srtnCd": "037440",
+    "fullNm": "희림종합건축사사무소",
+    "itmsNm": "희림",
+    "mrktCtg": "KOSDAQ"
+  },
+  {
+    "srtnCd": "238490",
+    "fullNm": "힘스",
+    "itmsNm": "힘스",
+    "mrktCtg": "KOSDAQ"
+  }
+]

--- a/client/src/Components/Global/Header/index.js
+++ b/client/src/Components/Global/Header/index.js
@@ -1,5 +1,7 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
+
+import Search from "./Search/index";
 import Clock from "./Clock";
 // 헤더 기본 구조
 // 로고 / 검색창 / 로그인버튼
@@ -42,15 +44,6 @@ const Main = styled.header`
   }
 `;
 
-const Search = styled.input`
-  width: 500px;
-  height: 30px;
-  border: solid 1.5px #495464;
-  border-radius: 3px;
-  margin: 15px 10px 15px 0;
-  padding-left: 9px;
-`;
-
 const LogDiv = styled.div`
   .user {
     margin: 15px auto auto 40px;
@@ -82,10 +75,11 @@ const Header = () => {
       </div>
       <div className="search">
         <div>
-          <Search placeholder="오늘의 주가는?" type="text"></Search>
+          <Search />
           <svg
             className="sicon"
             width="20"
+            height="60"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 512 512"
           >


### PR DESCRIPTION
![search](https://user-images.githubusercontent.com/111216062/212618823-0fd87bf4-4821-4aaf-8e5e-65cc9ddb5f36.gif)

feat Header 의 검색창에 자동완성, 클릭시 상세 조회 페이지로 이동하는 기능 구현

(구현 상황)
1. KRX 정보데이터 시스템에서 전종목 기본정보(이름, 코드, 상장날짜 등) 만 일괄로 다운이 가능하여 해당 정보를 data.json 으로 Header 폴더에 저장했습니다
// 임시 데이터 
[https://data.krx.co.kr/](url)
3. 자동완성 기능은 검색어가 변하는 시점에서 1초 단위로 작동합니다. (Autocomplete.js)
4. useNavigate로 상세 조회 페이지로 이동하는데, 이때 state는 name만 넘겨줍니다.(MarketCap 미적용) 

현재 문제(개선상황)
1. 페이지 이동 후에도 검색 창에 검색어가 그대로 남아있음
3.  영문 알파벳의 대소문자 구분이 현재 불가능 (ex. lg 로는 검색이 안되지만 LG 로는 검색이 됨)