### PR TITLE
Style 레이아웃 Grid로 수정

### DIFF
--- a/client/src/Components/Global/Footer/index.js
+++ b/client/src/Components/Global/Footer/index.js
@@ -2,10 +2,9 @@ import styled from "styled-components";
 
 const Main = styled.footer`
   display: flex;
+  grid-area: footer;
   height: 250px;
   width: 100%;
-  position: relative;
-  transfrom: translateY(-100%);
   background-color: #144272;
   color: white;
   flex-direction: column;

--- a/client/src/Components/Global/Header/index.js
+++ b/client/src/Components/Global/Header/index.js
@@ -9,6 +9,7 @@ import Clock from "./Clock";
 
 const Main = styled.header`
   display: grid;
+  grid-area: header;
   position: fixed;
   z-index: 100;
   background-color: white;

--- a/client/src/Components/Global/Sidebar/index.js
+++ b/client/src/Components/Global/Sidebar/index.js
@@ -2,12 +2,14 @@ import styled from "styled-components";
 import { Link, useLocation } from "react-router-dom";
 import { useEffect, useState } from "react";
 
-const Main = styled.aside`
+const Aside = styled.aside`
+  display: flex;
+  grid-area: side;
+  positon: fixed;
   float: left;
-  width: 115px;
+  width: 112px;
   border-right: double 3px #eeeeee;
 
-  position: fixed;
   top: 100px;
   bottom: 0;
   > ul li {
@@ -19,7 +21,7 @@ const Main = styled.aside`
 
 const StyledLink = styled(Link)`
   display: block;
-  width: 90px;
+  width: 100%;
   text-decoration: none;
   color: gray;
   font-size: 0.8em;
@@ -45,7 +47,7 @@ const Sidebar = () => {
     setNow(location.pathname);
   }, [location.pathname]);
   return (
-    <Main>
+    <Aside>
       <ul>
         <li>
           <StyledLink bgcolor={now === "/" ? "orange" : "white"} to="/">
@@ -64,7 +66,7 @@ const Sidebar = () => {
           <StyledLink>Mypage</StyledLink>
         </li>
       </ul>
-    </Main>
+    </Aside>
   );
 };
 

--- a/client/src/Components/Style/Layout.js
+++ b/client/src/Components/Style/Layout.js
@@ -5,34 +5,29 @@ import Sidebar from "../Global/Sidebar/index";
 import Footer from "../Global/Footer/index";
 
 const Div = styled.div`
-  height: 100%;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  min-height: 100vh;
+  grid-template-rows: 63px 15px auto 15px 250px;
+  grid-template-columns: 112px auto;
+  grid-template-areas:
+    "header header"
+    ". ."
+    "side main"
+    ". ."
+    "footer footer";
 `;
 
 const Wrapper = styled.main`
-  display: flex;
-  flex-direction: row;
-
-  height: auto;
-  position: relative;
-  min-height: 100%;
-  padding-bottom: 250px;
-  .content {
-    margin-top: 100px;
-    margin-left: 120px;
-    width: 100%;
-  }
+  display: grid;
+  grid-area: main;
 `;
 
 const Layout = ({ children }) => {
   return (
     <Div>
       <Header />
-      <Wrapper>
-        <Sidebar />
-        <section className="content">{children}</section>
-      </Wrapper>
+      <Sidebar />
+      <Wrapper>{children}</Wrapper>
       <Footer />
     </Div>
   );

--- a/client/src/Components/Style/Layout.js
+++ b/client/src/Components/Style/Layout.js
@@ -7,13 +7,11 @@ import Footer from "../Global/Footer/index";
 const Div = styled.div`
   display: grid;
   min-height: 100vh;
-  grid-template-rows: 63px 15px auto 15px 250px;
+  grid-template-rows: 63px auto 250px;
   grid-template-columns: 112px auto;
   grid-template-areas:
     "header header"
-    ". ."
     "side main"
-    ". ."
     "footer footer";
 `;
 

--- a/client/src/Page/Board/ArticleList/index.js
+++ b/client/src/Page/Board/ArticleList/index.js
@@ -55,7 +55,6 @@ const Board = () => {
   const [currentPage, setCurrentPage] = useState(1);
   useEffect(() => {
     axios.get(url).then((res) => {
-      console.log(res.data.slice(10 * currentPage - 9, 10 * currentPage));
       setData(res.data);
     });
   }, [currentPage]);
@@ -87,7 +86,9 @@ const Board = () => {
           <Article key={el.id} data={el} />
         ))}
       </div>
-      <div className="pagebutton">{pageRender(data.length / 10 + 1)}</div>
+      <div className="pagebutton">
+        {pageRender(data.length % 10 ? data.length / 10 + 1 : data.length / 10)}
+      </div>
     </Div>
   );
 };

--- a/client/src/Page/Board/Detail/index.js
+++ b/client/src/Page/Board/Detail/index.js
@@ -5,8 +5,7 @@ import { useParams } from "react-router-dom";
 
 const Div = styled.div`
   display: flex;
-  height: auto;
-  min-height: 100%;
+
   flex-direction: column;
   margin: 30px 50px;
   padding: 50px 50px;


### PR DESCRIPTION
![grid ](https://user-images.githubusercontent.com/111216062/212716969-7fb6db80-3913-4dff-bb04-f700e9fc78ff.gif)

1. grid 로 수정 ( 2*5)

h h
" "
s m
" "
f f

"는 15px 공백입니다.
높이를 header / 15px / auto / 15px / footer
로 나누어서 브라우저 30%까지 축소해도 footer 하단에 고정 되도록 수정
auto에 Main(content)가 들어갑니다. 